### PR TITLE
main: log self-pod name only if exists

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,7 +31,10 @@ func main() {
 	vers, _ := metrics.ResolveVersions(nil)
 	log.Info("Versions", "Versions", vers)
 
-	log.Info("Self", "PodID", metrics.GetSelfPodID())
+	podid := metrics.GetSelfPodID()
+	if len(podid.Name) > 0 {
+		log.Info("Self", "PodID", podid)
+	}
 
 	loc, err := metrics.LocateSmbStatus()
 	if err != nil {


### PR DESCRIPTION
When running under k8s (via samba-operator), the pod's name is populated via SAMBA_POD_NAME env variable. However, when running as stand-alone application it may not be set; avoid confusing logging when this is the case.