### PR TITLE
smbstatus json only

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,12 +33,12 @@ func main() {
 
 	log.Info("Self", "PodID", metrics.GetSelfPodID())
 
-	loc, err := metrics.LocateSmbStatus()
+	loc, err := metrics.LocateSMBStatus()
 	if err != nil {
 		log.Error(err, "Failed to locate smbstatus")
 		os.Exit(1)
 	}
-	ver, err := metrics.RunSmbStatusVersion()
+	ver, err := metrics.RunSMBStatusVersion()
 	if err != nil {
 		log.Error(err, "Failed to run smbstatus")
 		os.Exit(1)

--- a/internal/metrics/collectors.go
+++ b/internal/metrics/collectors.go
@@ -119,7 +119,7 @@ type smbLocksCollector struct {
 }
 
 func (col *smbLocksCollector) Collect(ch chan<- prometheus.Metric) {
-	locks, _ := RunSmbStatusLocks()
+	locks, _ := RunSmbStatusLockedFiles()
 	ch <- prometheus.MustNewConstMetric(col.dsc[0],
 		prometheus.GaugeValue, float64(len(locks)))
 }

--- a/internal/metrics/collectors.go
+++ b/internal/metrics/collectors.go
@@ -119,7 +119,7 @@ type smbLocksCollector struct {
 }
 
 func (col *smbLocksCollector) Collect(ch chan<- prometheus.Metric) {
-	locks, _ := RunSmbStatusLockedFiles()
+	locks, _ := RunSmbStatusLocks()
 	ch <- prometheus.MustNewConstMetric(col.dsc[0],
 		prometheus.GaugeValue, float64(len(locks)))
 }

--- a/internal/metrics/collectors.go
+++ b/internal/metrics/collectors.go
@@ -85,7 +85,7 @@ type smbSharesCollector struct {
 
 func (col *smbSharesCollector) Collect(ch chan<- prometheus.Metric) {
 	sharesTotal := 0
-	sharesMap, _ := SmbStatusSharesByMachine()
+	sharesMap, _ := SMBStatusSharesByMachine()
 	for machine, share := range sharesMap {
 		sharesCount := len(share)
 		ch <- prometheus.MustNewConstMetric(col.dsc[0],
@@ -119,7 +119,7 @@ type smbLocksCollector struct {
 }
 
 func (col *smbLocksCollector) Collect(ch chan<- prometheus.Metric) {
-	locks, _ := RunSmbStatusLocks()
+	locks, _ := RunSMBStatusLocks()
 	ch <- prometheus.MustNewConstMetric(col.dsc[0],
 		prometheus.GaugeValue, float64(len(locks)))
 }

--- a/internal/metrics/smbstatus.go
+++ b/internal/metrics/smbstatus.go
@@ -49,9 +49,13 @@ type SmbStatusSession struct {
 	GID            int                 `json:"gid"`
 	Username       string              `json:"username"`
 	Groupname      string              `json:"groupname"`
+	CreationTime   string              `json:"creation_time"`
+	ExpirationTime string              `json:"expiration_time"`
+	AuthTime       string              `json:"auth_time"`
 	RemoteMachine  string              `json:"remote_machine"`
 	Hostname       string              `json:"hostname"`
 	SessionDialect string              `json:"session_dialect"`
+	ClientGUID     string              `json:"client_guid"`
 	Encryption     SmbStatusEncryption `json:"encryption"`
 	Signing        SmbStatusSigning    `json:"signing"`
 }

--- a/internal/metrics/smbstatus.go
+++ b/internal/metrics/smbstatus.go
@@ -10,42 +10,42 @@ import (
 	"strings"
 )
 
-// SmbStatusServerID represents a server_id output field
-type SmbStatusServerID struct {
+// SMBStatusServerID represents a server_id output field
+type SMBStatusServerID struct {
 	PID      string `json:"pid"`
 	TaskID   string `json:"task_id"`
 	VNN      string `json:"vnn"`
 	UniqueID string `json:"unique_id"`
 }
 
-// SmbStatusEncryption represents a encryption output field
-type SmbStatusEncryption struct {
+// SMBStatusEncryption represents a encryption output field
+type SMBStatusEncryption struct {
 	Cipher string `json:"cipher"`
 	Degree string `json:"degree"`
 }
 
-// SmbStatusSigning represents a signing output field
-type SmbStatusSigning struct {
+// SMBStatusSigning represents a signing output field
+type SMBStatusSigning struct {
 	Cipher string `json:"cipher"`
 	Degree string `json:"degree"`
 }
 
-// SmbStatusTreeCon represents a 'tcon' output field
-type SmbStatusTreeCon struct {
+// SMBStatusTreeCon represents a 'tcon' output field
+type SMBStatusTreeCon struct {
 	Service     string              `json:"service"`
-	ServerID    SmbStatusServerID   `json:"server_id"`
+	ServerID    SMBStatusServerID   `json:"server_id"`
 	TConID      string              `json:"tcon_id"`
 	SessionID   string              `json:"session_id"`
 	Machine     string              `json:"machine"`
 	ConnectedAt string              `json:"connected_at"`
-	Encryption  SmbStatusEncryption `json:"encryption"`
-	Signing     SmbStatusSigning    `json:"signing"`
+	Encryption  SMBStatusEncryption `json:"encryption"`
+	Signing     SMBStatusSigning    `json:"signing"`
 }
 
-// SmbStatusSession represents a session output field
-type SmbStatusSession struct {
+// SMBStatusSession represents a session output field
+type SMBStatusSession struct {
 	SessionID      string              `json:"session_id"`
-	ServerID       SmbStatusServerID   `json:"server_id"`
+	ServerID       SMBStatusServerID   `json:"server_id"`
 	UID            int                 `json:"uid"`
 	GID            int                 `json:"gid"`
 	Username       string              `json:"username"`
@@ -57,45 +57,45 @@ type SmbStatusSession struct {
 	Hostname       string              `json:"hostname"`
 	SessionDialect string              `json:"session_dialect"`
 	ClientGUID     string              `json:"client_guid"`
-	Encryption     SmbStatusEncryption `json:"encryption"`
-	Signing        SmbStatusSigning    `json:"signing"`
+	Encryption     SMBStatusEncryption `json:"encryption"`
+	Signing        SMBStatusSigning    `json:"signing"`
 }
 
-// SmbStatusFileID represents a fileid output field
-type SmbStatusFileID struct {
+// SMBStatusFileID represents a fileid output field
+type SMBStatusFileID struct {
 	DevID int64 `json:"devid"`
 	Inode int64 `json:"inode"`
 	Extid int32 `json:"extid"`
 }
 
-// SmbStatusLockedFile represents a locked-file output field
-type SmbStatusLockedFile struct {
+// SMBStatusLockedFile represents a locked-file output field
+type SMBStatusLockedFile struct {
 	ServicePath       string          `json:"service_path"`
 	Filename          string          `json:"filename"`
-	FileID            SmbStatusFileID `json:"fileid"`
+	FileID            SMBStatusFileID `json:"fileid"`
 	NumPendingDeletes int             `json:"num_pending_deletes"`
 }
 
-// SmbStatus represents output of 'smbstatus --json'
-type SmbStatus struct {
+// SMBStatus represents output of 'smbstatus --json'
+type SMBStatus struct {
 	Timestamp   string                         `json:"timestamp"`
 	Version     string                         `json:"version"`
 	SmbConf     string                         `json:"smb_conf"`
-	Sessions    map[string]SmbStatusSession    `json:"sessions"`
-	TCons       map[string]SmbStatusTreeCon    `json:"tcons"`
-	LockedFiles map[string]SmbStatusLockedFile `json:"locked_files"`
+	Sessions    map[string]SMBStatusSession    `json:"sessions"`
+	TCons       map[string]SMBStatusTreeCon    `json:"tcons"`
+	LockedFiles map[string]SMBStatusLockedFile `json:"locked_files"`
 }
 
-// SmbStatusLocks represents output of 'smbstatus -L --json'
-type SmbStatusLocks struct {
+// SMBStatusLocks represents output of 'smbstatus -L --json'
+type SMBStatusLocks struct {
 	Timestamp string                         `json:"timestamp"`
 	Version   string                         `json:"version"`
 	SmbConf   string                         `json:"smb_conf"`
-	OpenFiles map[string]SmbStatusLockedFile `json:"open_files"`
+	OpenFiles map[string]SMBStatusLockedFile `json:"open_files"`
 }
 
-// LocateSmbStatus finds the local executable of 'smbstatus' on host.
-func LocateSmbStatus() (string, error) {
+// LocateSMBStatus finds the local executable of 'smbstatus' on host.
+func LocateSMBStatus() (string, error) {
 	knowns := []string{
 		"/usr/bin/smbstatus",
 	}
@@ -115,27 +115,27 @@ func LocateSmbStatus() (string, error) {
 	return "", errors.New("failed to locate smbstatus")
 }
 
-// RunSmbStatusVersion executes 'smbstatus --version' on host container
-func RunSmbStatusVersion() (string, error) {
-	ver, err := executeSmbStatusCommand("--version")
+// RunSMBStatusVersion executes 'smbstatus --version' on host container
+func RunSMBStatusVersion() (string, error) {
+	ver, err := executeSMBStatusCommand("--version")
 	if err != nil {
 		return "", err
 	}
 	return ver, nil
 }
 
-// RunSmbStatusShares executes 'smbstatus --shares --json' on host
-func RunSmbStatusShares() ([]SmbStatusTreeCon, error) {
-	dat, err := executeSmbStatusCommand("--shares --json")
+// RunSMBStatusShares executes 'smbstatus --shares --json' on host
+func RunSMBStatusShares() ([]SMBStatusTreeCon, error) {
+	dat, err := executeSMBStatusCommand("--shares --json")
 	if err != nil {
-		return []SmbStatusTreeCon{}, err
+		return []SMBStatusTreeCon{}, err
 	}
-	return parseSmbStatusTreeCons(dat)
+	return parseSMBStatusTreeCons(dat)
 }
 
-func parseSmbStatusTreeCons(dat string) ([]SmbStatusTreeCon, error) {
-	tcons := []SmbStatusTreeCon{}
-	res, err := parseSmbStatus(dat)
+func parseSMBStatusTreeCons(dat string) ([]SMBStatusTreeCon, error) {
+	tcons := []SMBStatusTreeCon{}
+	res, err := parseSMBStatus(dat)
 	if err != nil {
 		return tcons, err
 	}
@@ -145,18 +145,18 @@ func parseSmbStatusTreeCons(dat string) ([]SmbStatusTreeCon, error) {
 	return tcons, nil
 }
 
-// RunSmbStatusLocks executes 'smbstatus --locks --json' on host
-func RunSmbStatusLocks() ([]SmbStatusLockedFile, error) {
-	dat, err := executeSmbStatusCommand("--locks --json")
+// RunSMBStatusLocks executes 'smbstatus --locks --json' on host
+func RunSMBStatusLocks() ([]SMBStatusLockedFile, error) {
+	dat, err := executeSMBStatusCommand("--locks --json")
 	if err != nil {
-		return []SmbStatusLockedFile{}, err
+		return []SMBStatusLockedFile{}, err
 	}
-	return parseSmbStatusLockedFiles(dat)
+	return parseSMBStatusLockedFiles(dat)
 }
 
-func parseSmbStatusLockedFiles(dat string) ([]SmbStatusLockedFile, error) {
-	lockedFiles := []SmbStatusLockedFile{}
-	res, err := parseSmbStatusLocks(dat)
+func parseSMBStatusLockedFiles(dat string) ([]SMBStatusLockedFile, error) {
+	lockedFiles := []SMBStatusLockedFile{}
+	res, err := parseSMBStatusLocks(dat)
 	if err != nil {
 		return lockedFiles, err
 	}
@@ -166,26 +166,26 @@ func parseSmbStatusLockedFiles(dat string) ([]SmbStatusLockedFile, error) {
 	return lockedFiles, nil
 }
 
-// SmbStatusSharesByMachine converts the output of RunSmbStatusShares into map
+// SMBStatusSharesByMachine converts the output of RunSMBStatusShares into map
 // indexed by machine's host
-func SmbStatusSharesByMachine() (map[string][]SmbStatusTreeCon, error) {
-	tcons, err := RunSmbStatusShares()
+func SMBStatusSharesByMachine() (map[string][]SMBStatusTreeCon, error) {
+	tcons, err := RunSMBStatusShares()
 	if err != nil {
-		return map[string][]SmbStatusTreeCon{}, err
+		return map[string][]SMBStatusTreeCon{}, err
 	}
 	return makeSmbSharesMap(tcons), nil
 }
 
-func makeSmbSharesMap(tcons []SmbStatusTreeCon) map[string][]SmbStatusTreeCon {
-	ret := map[string][]SmbStatusTreeCon{}
+func makeSmbSharesMap(tcons []SMBStatusTreeCon) map[string][]SMBStatusTreeCon {
+	ret := map[string][]SMBStatusTreeCon{}
 	for _, share := range tcons {
 		ret[share.Machine] = append(ret[share.Machine], share)
 	}
 	return ret
 }
 
-func executeSmbStatusCommand(args ...string) (string, error) {
-	loc, err := LocateSmbStatus()
+func executeSMBStatusCommand(args ...string) (string, error) {
+	loc, err := LocateSMBStatus()
 	if err != nil {
 		return "", err
 	}
@@ -202,18 +202,18 @@ func executeCommand(command string, arg ...string) (string, error) {
 	return res, nil
 }
 
-// parseSmbStatus parses to output of 'smbstatus --json' into internal
+// parseSMBStatus parses to output of 'smbstatus --json' into internal
 // representation.
-func parseSmbStatus(data string) (*SmbStatus, error) {
-	res := SmbStatus{}
+func parseSMBStatus(data string) (*SMBStatus, error) {
+	res := SMBStatus{}
 	err := json.Unmarshal([]byte(data), &res)
 	return &res, err
 }
 
-// parseSmbStatusLocks parses to output of 'smbstatus --locks --json' into
+// parseSMBStatusLocks parses to output of 'smbstatus --locks --json' into
 // internal representation.
-func parseSmbStatusLocks(data string) (*SmbStatusLocks, error) {
-	res := SmbStatusLocks{}
+func parseSMBStatusLocks(data string) (*SMBStatusLocks, error) {
+	res := SMBStatusLocks{}
 	err := json.Unmarshal([]byte(data), &res)
 	return &res, err
 }

--- a/internal/metrics/smbstatus_test.go
+++ b/internal/metrics/smbstatus_test.go
@@ -451,6 +451,142 @@ Pid          User(ID)   DenyMode   Access      R/W        Oplock           Share
 	}
   }
   `
+
+	outputSmbStatusLocksJSON = `
+  {
+	"timestamp": "2024-04-14T14:53:34.901974+0300",
+	"version": "4.21.0pre1-GIT-58a018fb7ad",
+	"smb_conf": "//etc/samba/smb.conf",
+	"open_files": {
+	  "/A/A2/A6/r1": {
+	    "service_path": "/",
+	    "filename": "A/A2/A6/r1",
+	    "fileid": {
+	      "devid": 1,
+	      "inode": 61,
+	      "extid": 0
+	    },
+	    "num_pending_deletes": 0,
+	    "opens": {
+	      "1790/261": {
+		"server_id": {
+		  "pid": "1790",
+		  "task_id": "0",
+		  "vnn": "4294967295",
+		  "unique_id": "3607086338167075363"
+		},
+		"uid": 2222,
+		"share_file_id": "261",
+		"sharemode": {
+		  "hex": "0x00000007",
+		  "READ": true,
+		  "WRITE": true,
+		  "DELETE": true,
+		  "text": "RWD"
+		},
+		"access_mask": {
+		  "hex": "0x00120089",
+		  "READ_DATA": true,
+		  "WRITE_DATA": false,
+		  "APPEND_DATA": false,
+		  "READ_EA": true,
+		  "WRITE_EA": false,
+		  "EXECUTE": false,
+		  "READ_ATTRIBUTES": true,
+		  "WRITE_ATTRIBUTES": false,
+		  "DELETE_CHILD": false,
+		  "DELETE": false,
+		  "READ_CONTROL": true,
+		  "WRITE_DAC": false,
+		  "SYNCHRONIZE": true,
+		  "ACCESS_SYSTEM_SECURITY": false,
+		  "text": "R"
+		},
+		"caching": {
+		  "READ": true,
+		  "WRITE": true,
+		  "HANDLE": false,
+		  "hex": "0x00000005",
+		  "text": "RW"
+		},
+		"oplock": {
+		  "EXCLUSIVE": true,
+		  "BATCH": true,
+		  "LEVEL_II": false,
+		  "LEASE": false,
+		  "text": "BATCH"
+		},
+		"lease": {},
+		"opened_at": "2024-04-14T14:53:15.569085+03:00"
+	      }
+	    }
+	  },
+	  "/A/A1/r2": {
+	    "service_path": "/",
+	    "filename": "A/A1/r2",
+	    "fileid": {
+	      "devid": 2,
+	      "inode": 52,
+	      "extid": 0
+	    },
+	    "num_pending_deletes": 2,
+	    "opens": {
+	      "1790/267": {
+		"server_id": {
+		  "pid": "1790",
+		  "task_id": "0",
+		  "vnn": "4294967295",
+		  "unique_id": "3607086338167075363"
+		},
+		"uid": 1111,
+		"share_file_id": "222",
+		"sharemode": {
+		  "hex": "0x00000007",
+		  "READ": true,
+		  "WRITE": true,
+		  "DELETE": true,
+		  "text": "RWD"
+		},
+		"access_mask": {
+		  "hex": "0x00120089",
+		  "READ_DATA": true,
+		  "WRITE_DATA": false,
+		  "APPEND_DATA": false,
+		  "READ_EA": true,
+		  "WRITE_EA": false,
+		  "EXECUTE": false,
+		  "READ_ATTRIBUTES": true,
+		  "WRITE_ATTRIBUTES": false,
+		  "DELETE_CHILD": false,
+		  "DELETE": false,
+		  "READ_CONTROL": true,
+		  "WRITE_DAC": false,
+		  "SYNCHRONIZE": true,
+		  "ACCESS_SYSTEM_SECURITY": false,
+		  "text": "R"
+		},
+		"caching": {
+		  "READ": true,
+		  "WRITE": true,
+		  "HANDLE": false,
+		  "hex": "0x00000005",
+		  "text": "RW"
+		},
+		"oplock": {
+		  "EXCLUSIVE": true,
+		  "BATCH": true,
+		  "LEVEL_II": false,
+		  "LEASE": false,
+		  "text": "BATCH"
+		},
+		"lease": {},
+		"opened_at": "2024-04-14T14:53:32.258325+03:00"
+	      }
+	    }
+	  }
+	}
+      }
+  `
 )
 
 //revive:enable line-length-limit
@@ -538,4 +674,16 @@ func TestParseSmbStatusLocks(t *testing.T) {
 	assert.Equal(t, lock1.UserID, "1001")
 	assert.Equal(t, lock1.DenyMode, "DENY_NONE")
 	assert.Equal(t, lock1.RW, "RDONLY")
+}
+
+func TestParseSmbStatusLocksJSON(t *testing.T) {
+	locks, err := parseSmbStatusLocksAsJSON(outputSmbStatusLocksJSON)
+	assert.NoError(t, err)
+	assert.Equal(t, len(locks), 2)
+	lock1 := locks[0]
+	assert.Equal(t, lock1.FileID.Inode, int64(61))
+	assert.Equal(t, lock1.NumPendingDeletes, 0)
+	lock2 := locks[1]
+	assert.Equal(t, lock2.FileID.Inode, int64(52))
+	assert.Equal(t, lock2.NumPendingDeletes, 2)
 }

--- a/internal/metrics/smbstatus_test.go
+++ b/internal/metrics/smbstatus_test.go
@@ -11,44 +11,6 @@ import (
 //revive:disable line-length-limit
 //nolint:revive,lll
 var (
-	outputSmbStatusS = `
-
-	Service      pid     Machine       Connected at                     Encryption   Signing
-	----------------------------------------------------------------------------------------
-	share_test   13668   10.66.208.149 Wed Sep 27 10:33:55 AM 2017 CST  -            -
-	share_test2  13669   10.66.208.149 Wed Sep 27 10:35:56 AM 2022 CST  -            -
-	IPC$         651248  10.0.0.100    Sat Sep  4 10:37:01 AM 2020 MDT  -            -
-
-`
-
-	outputSmbStatusS2 = `
-
-Service      pid     Machine       Connected at                     Encryption Signing
----------------------------------------------------------------------------------------------
-samba-share  295     ::1           Thu Apr  7 14:33:19 2022 UTC     -          -
-IPC$         295     ::1           Thu Apr  7 14:33:19 2022 UTC     -          -
-
-`
-
-	outputSmbStatusp = `
-
-Samba version 4.14.12
-PID     Username     Group        Machine                                   Protocol Version  Encryption           Signing
-----------------------------------------------------------------------------------------------------------------------------------------
-245     user         user         127.0.0.1 (ipv4:127.0.0.1:55106)          SMB3_11           -                    partial(AES-128-CMAC)
-9701    root         wheel        10.0.0.2 (ipv4:10.0.0.2:55107)            SMB3_12           -                    partial(AES-128-CMAC)
-
-`
-
-	outputSmbStatusL = `
-
-Locked files:
-Pid          User(ID)   DenyMode   Access      R/W        Oplock           SharePath   Name   Time
---------------------------------------------------------------------------------------------------
-241          1001       DENY_NONE  0x120089    RDONLY     LEASE(RWH)       /mnt/514cd7ba-d858-4d3a-bed9-68e4e524493b   A/a   Mon Feb 21 13:07:46 2022
-
-`
-
 	outputSmbStatusJSON = `
 {
 	"timestamp": "2022-07-19T16:26:34.652845+0530",
@@ -591,26 +553,6 @@ Pid          User(ID)   DenyMode   Access      R/W        Oplock           Share
 
 //revive:enable line-length-limit
 
-func TestParseSmbStatusShares(t *testing.T) {
-	shares, err := parseSmbStatusShares(outputSmbStatusS)
-	assert.NoError(t, err)
-	assert.Equal(t, len(shares), 2)
-	share1 := shares[0]
-	assert.Equal(t, share1.Service, "share_test")
-	assert.Equal(t, share1.ServerID.PID, "13668")
-	assert.Equal(t, share1.Machine, "10.66.208.149")
-	assert.Equal(t, share1.Encryption.Cipher, "-")
-	assert.Equal(t, share1.Signing.Cipher, "-")
-
-	shares, err = parseSmbStatusShares(outputSmbStatusS2)
-	assert.NoError(t, err)
-	assert.Equal(t, len(shares), 1)
-	share1 = shares[0]
-	assert.Equal(t, share1.Service, "samba-share")
-	assert.Equal(t, share1.ServerID.PID, "295")
-	assert.Equal(t, share1.Machine, "::1")
-}
-
 func TestParseSmbStatusSharesJSON(t *testing.T) {
 	dat, err := parseSmbStatusJSON(outputSmbStatusJSON)
 	assert.NoError(t, err)
@@ -647,33 +589,6 @@ func TestParseSmbStatusAllJSON(t *testing.T) {
 	dat2, err := parseSmbStatusJSON(outputSmbStatusAllJSON2)
 	assert.NoError(t, err)
 	assert.Equal(t, len(dat2.LockedFiles), 2)
-}
-
-func TestParseSmbStatusProcs(t *testing.T) {
-	procs, err := parseSmbStatusProcs(outputSmbStatusp)
-	assert.NoError(t, err)
-	assert.Equal(t, len(procs), 2)
-	proc1 := procs[0]
-	assert.Equal(t, proc1.PID, "245")
-	assert.Equal(t, proc1.Username, "user")
-	assert.Equal(t, proc1.Group, "user")
-	assert.Equal(t, proc1.ProtocolVersion, "SMB3_11")
-	proc2 := procs[1]
-	assert.Equal(t, proc2.PID, "9701")
-	assert.Equal(t, proc2.Username, "root")
-	assert.Equal(t, proc2.Group, "wheel")
-	assert.Equal(t, proc2.ProtocolVersion, "SMB3_12")
-}
-
-func TestParseSmbStatusLocks(t *testing.T) {
-	locks, err := parseSmbStatusLocks(outputSmbStatusL)
-	assert.NoError(t, err)
-	assert.Equal(t, len(locks), 1)
-	lock1 := locks[0]
-	assert.Equal(t, lock1.PID, "241")
-	assert.Equal(t, lock1.UserID, "1001")
-	assert.Equal(t, lock1.DenyMode, "DENY_NONE")
-	assert.Equal(t, lock1.RW, "RDONLY")
 }
 
 func TestParseSmbStatusLocksJSON(t *testing.T) {

--- a/internal/metrics/smbstatus_test.go
+++ b/internal/metrics/smbstatus_test.go
@@ -553,16 +553,16 @@ var (
 
 //revive:enable line-length-limit
 
-func TestParseSmbStatusTCons(t *testing.T) {
-	dat, err := parseSmbStatus(smbstatusOutput1)
+func TestParseSMBStatusTCons(t *testing.T) {
+	dat, err := parseSMBStatus(smbstatusOutput1)
 	assert.NoError(t, err)
 	assert.Equal(t, len(dat.TCons), 2)
 
-	dat, err = parseSmbStatus(smbstatusOutput2)
+	dat, err = parseSMBStatus(smbstatusOutput2)
 	assert.NoError(t, err)
 	assert.Equal(t, len(dat.TCons), 1)
 
-	shares, err := parseSmbStatusTreeCons(smbstatusOutput2)
+	shares, err := parseSMBStatusTreeCons(smbstatusOutput2)
 	assert.NoError(t, err)
 	assert.Equal(t, len(shares), 1)
 	share1 := shares[0]
@@ -579,20 +579,20 @@ func TestParseSmbStatusTCons(t *testing.T) {
 	}
 }
 
-func TestParseSmbStatusAll(t *testing.T) {
-	dat, err := parseSmbStatus(smbstatusOutput3)
+func TestParseSMBStatusAll(t *testing.T) {
+	dat, err := parseSMBStatus(smbstatusOutput3)
 	assert.NoError(t, err)
 	assert.Equal(t, len(dat.Sessions), 1)
 	assert.Equal(t, len(dat.TCons), 1)
 	assert.Equal(t, len(dat.LockedFiles), 1)
 
-	dat2, err := parseSmbStatus(smbstatusOutput4)
+	dat2, err := parseSMBStatus(smbstatusOutput4)
 	assert.NoError(t, err)
 	assert.Equal(t, len(dat2.LockedFiles), 2)
 }
 
-func TestParseSmbStatusLocks(t *testing.T) {
-	locks, err := parseSmbStatusLockedFiles(smbstatusLocksOutput)
+func TestParseSMBStatusLocks(t *testing.T) {
+	locks, err := parseSMBStatusLockedFiles(smbstatusLocksOutput)
 	assert.NoError(t, err)
 	assert.Equal(t, len(locks), 2)
 	lock1 := locks[0]

--- a/internal/metrics/smbstatus_test.go
+++ b/internal/metrics/smbstatus_test.go
@@ -11,7 +11,7 @@ import (
 //revive:disable line-length-limit
 //nolint:revive,lll
 var (
-	outputSmbStatusJSON = `
+	smbstatusOutput1 = `
 {
 	"timestamp": "2022-07-19T16:26:34.652845+0530",
 	"version": "4.17.0pre1-GIT-130283cbae0",
@@ -63,7 +63,7 @@ var (
   }
   `
 
-	outputSmbStatusJSON2 = `
+	smbstatusOutput2 = `
   {
 	"timestamp": "2023-06-07T11:49:05.528375+0000",
 	"version": "4.17.8",
@@ -93,7 +93,7 @@ var (
 	}
   }`
 
-	outputSmbStatusAllJSON = `
+	smbstatusOutput3 = `
   {
 	"timestamp": "2022-04-15T18:25:15.364891+0200",
 	"version": "4.17.0pre1-GIT-a0f12b9c80b",
@@ -217,7 +217,7 @@ var (
 
   `
 
-	outputSmbStatusAllJSON2 = `
+	smbstatusOutput4 = `
   {
 	"timestamp": "2022-07-20T12:07:36.225955+0000",
 	"version": "4.17.0pre1-UNKNOWN",
@@ -414,7 +414,7 @@ var (
   }
   `
 
-	outputSmbStatusLocksJSON = `
+	smbstatusLocksOutput = `
   {
 	"timestamp": "2024-04-14T14:53:34.901974+0300",
 	"version": "4.21.0pre1-GIT-58a018fb7ad",
@@ -553,16 +553,16 @@ var (
 
 //revive:enable line-length-limit
 
-func TestParseSmbStatusSharesJSON(t *testing.T) {
-	dat, err := parseSmbStatusJSON(outputSmbStatusJSON)
+func TestParseSmbStatusTCons(t *testing.T) {
+	dat, err := parseSmbStatus(smbstatusOutput1)
 	assert.NoError(t, err)
 	assert.Equal(t, len(dat.TCons), 2)
 
-	dat, err = parseSmbStatusJSON(outputSmbStatusJSON2)
+	dat, err = parseSmbStatus(smbstatusOutput2)
 	assert.NoError(t, err)
 	assert.Equal(t, len(dat.TCons), 1)
 
-	shares, err := parseSmbStatusSharesAsJSON(outputSmbStatusJSON2)
+	shares, err := parseSmbStatusTreeCons(smbstatusOutput2)
 	assert.NoError(t, err)
 	assert.Equal(t, len(shares), 1)
 	share1 := shares[0]
@@ -579,20 +579,20 @@ func TestParseSmbStatusSharesJSON(t *testing.T) {
 	}
 }
 
-func TestParseSmbStatusAllJSON(t *testing.T) {
-	dat, err := parseSmbStatusJSON(outputSmbStatusAllJSON)
+func TestParseSmbStatusAll(t *testing.T) {
+	dat, err := parseSmbStatus(smbstatusOutput3)
 	assert.NoError(t, err)
 	assert.Equal(t, len(dat.Sessions), 1)
 	assert.Equal(t, len(dat.TCons), 1)
 	assert.Equal(t, len(dat.LockedFiles), 1)
 
-	dat2, err := parseSmbStatusJSON(outputSmbStatusAllJSON2)
+	dat2, err := parseSmbStatus(smbstatusOutput4)
 	assert.NoError(t, err)
 	assert.Equal(t, len(dat2.LockedFiles), 2)
 }
 
-func TestParseSmbStatusLocksJSON(t *testing.T) {
-	locks, err := parseSmbStatusLocksAsJSON(outputSmbStatusLocksJSON)
+func TestParseSmbStatusLocks(t *testing.T) {
+	locks, err := parseSmbStatusLockedFiles(smbstatusLocksOutput)
 	assert.NoError(t, err)
 	assert.Equal(t, len(locks), 2)
 	lock1 := locks[0]


### PR DESCRIPTION
The JSON output of `smbstatus` has more details then raw textual format and naturally, more easy to parse via Go standard libraries. Drop support to legacy text format and do some trivial code-cleanups on the way.