### PR TITLE
Improved exported metrics set

### DIFF
--- a/internal/metrics/collectors.go
+++ b/internal/metrics/collectors.go
@@ -12,9 +12,9 @@ var (
 
 func (sme *smbMetricsExporter) register() error {
 	cols := []prometheus.Collector{
-		sme.newSmbVersionsCollector(),
-		sme.newSmbSharesCollector(),
-		sme.newSmbLocksCollector(),
+		sme.newSMBVersionsCollector(),
+		sme.newSMBSharesCollector(),
+		sme.newSMBLocksCollector(),
 	}
 	for _, c := range cols {
 		if err := sme.reg.Register(c); err != nil {
@@ -60,7 +60,7 @@ func (col *smbVersionsCollector) Collect(ch chan<- prometheus.Metric) {
 	)
 }
 
-func (sme *smbMetricsExporter) newSmbVersionsCollector() prometheus.Collector {
+func (sme *smbMetricsExporter) newSMBVersionsCollector() prometheus.Collector {
 	col := &smbVersionsCollector{}
 	col.sme = sme
 	col.clnt, _ = newKClient()
@@ -97,7 +97,7 @@ func (col *smbSharesCollector) Collect(ch chan<- prometheus.Metric) {
 		prometheus.GaugeValue, float64(sharesTotal))
 }
 
-func (sme *smbMetricsExporter) newSmbSharesCollector() prometheus.Collector {
+func (sme *smbMetricsExporter) newSMBSharesCollector() prometheus.Collector {
 	col := &smbSharesCollector{}
 	col.sme = sme
 	col.dsc = []*prometheus.Desc{
@@ -124,7 +124,7 @@ func (col *smbLocksCollector) Collect(ch chan<- prometheus.Metric) {
 		prometheus.GaugeValue, float64(len(locks)))
 }
 
-func (sme *smbMetricsExporter) newSmbLocksCollector() prometheus.Collector {
+func (sme *smbMetricsExporter) newSMBLocksCollector() prometheus.Collector {
 	col := &smbLocksCollector{}
 	col.sme = sme
 	col.dsc = []*prometheus.Desc{

--- a/internal/metrics/collectors.go
+++ b/internal/metrics/collectors.go
@@ -87,13 +87,13 @@ func (col *smbActivityCollector) Collect(ch chan<- prometheus.Metric) {
 	totalSessions := 0
 	totalTreeCons := 0
 	totalConnectedUsers := 0
-	totalLockedFiles := 0
+	totalOpenFiles := 0
 	smbInfo, err := NewUpdatedSMBInfo()
 	if err == nil {
 		totalSessions = smbInfo.TotalSessions()
 		totalTreeCons = smbInfo.TotalTreeCons()
 		totalConnectedUsers = smbInfo.TotalConnectedUsers()
-		totalLockedFiles = smbInfo.TotalLockedFiles()
+		totalOpenFiles = smbInfo.TotalOpenFiles()
 	}
 	ch <- prometheus.MustNewConstMetric(col.dsc[0],
 		prometheus.GaugeValue, float64(totalSessions))
@@ -105,7 +105,7 @@ func (col *smbActivityCollector) Collect(ch chan<- prometheus.Metric) {
 		prometheus.GaugeValue, float64(totalConnectedUsers))
 
 	ch <- prometheus.MustNewConstMetric(col.dsc[3],
-		prometheus.GaugeValue, float64(totalLockedFiles))
+		prometheus.GaugeValue, float64(totalOpenFiles))
 }
 
 func (sme *smbMetricsExporter) newSMBActivityCollector() prometheus.Collector {
@@ -128,8 +128,8 @@ func (sme *smbMetricsExporter) newSMBActivityCollector() prometheus.Collector {
 			[]string{}, nil),
 
 		prometheus.NewDesc(
-			collectorName("locks", "total"),
-			"Number of currently active file-locks",
+			collectorName("openfiles", "total"),
+			"Number of currently open files",
 			[]string{}, nil),
 	}
 	return col

--- a/internal/metrics/smbinfo.go
+++ b/internal/metrics/smbinfo.go
@@ -36,8 +36,8 @@ func (smbinfo *SMBInfo) TotalTreeCons() int {
 	return len(smbinfo.smbstat.TCons)
 }
 
-func (smbinfo *SMBInfo) TotalLockedFiles() int {
-	return len(smbinfo.smbstat.LockedFiles)
+func (smbinfo *SMBInfo) TotalOpenFiles() int {
+	return len(smbinfo.smbstat.OpenFiles)
 }
 
 func (smbinfo *SMBInfo) TotalConnectedUsers() int {

--- a/internal/metrics/smbinfo.go
+++ b/internal/metrics/smbinfo.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+// SMBInfo provides a bridge layer between raw smbstatus info and exported
+// metric counters. It also implements the more complex logic which requires in
+// memory re-mapping of the low-level information (e.g., stats by machine/user).
+type SMBInfo struct {
+	smbstat *SMBStatus
+}
+
+func NewSMBInfo() *SMBInfo {
+	return &SMBInfo{smbstat: NewSMBStatus()}
+}
+
+func NewUpdatedSMBInfo() (*SMBInfo, error) {
+	smbinfo := NewSMBInfo()
+	err := smbinfo.Update()
+	return smbinfo, err
+}
+
+func (smbinfo *SMBInfo) Update() error {
+	smbstat, err := RunSMBStatus()
+	if err != nil {
+		return err
+	}
+	smbinfo.smbstat = smbstat
+	return nil
+}
+
+func (smbinfo *SMBInfo) TotalSessions() int {
+	return len(smbinfo.smbstat.Sessions)
+}
+
+func (smbinfo *SMBInfo) TotalTreeCons() int {
+	return len(smbinfo.smbstat.TCons)
+}
+
+func (smbinfo *SMBInfo) TotalLockedFiles() int {
+	return len(smbinfo.smbstat.LockedFiles)
+}
+
+func (smbinfo *SMBInfo) TotalConnectedUsers() int {
+	users := map[string]bool{}
+	for _, session := range smbinfo.smbstat.Sessions {
+		username := session.Username
+		if len(username) > 0 {
+			users[username] = true
+		}
+	}
+	return len(users)
+}
+
+func (smbinfo *SMBInfo) MapMachineToSessions() map[string][]*SMBStatusSession {
+	ret := map[string][]*SMBStatusSession{}
+	for _, session := range smbinfo.smbstat.Sessions {
+		machineID := session.RemoteMachine
+		sessionRef := &session
+		ret[machineID] = append(ret[machineID], sessionRef)
+	}
+	return ret
+}
+
+func (smbinfo *SMBInfo) MapServiceToTreeCons() map[string][]*SMBStatusTreeCon {
+	ret := map[string][]*SMBStatusTreeCon{}
+	for _, tcon := range smbinfo.smbstat.TCons {
+		serviceID := tcon.Service
+		tconRef := &tcon
+		ret[serviceID] = append(ret[serviceID], tconRef)
+	}
+	return ret
+}
+
+func (smbinfo *SMBInfo) MapMachineToTreeCons() map[string][]*SMBStatusTreeCon {
+	ret := map[string][]*SMBStatusTreeCon{}
+	for _, tcon := range smbinfo.smbstat.TCons {
+		machineID := tcon.Machine
+		tconRef := &tcon
+		ret[machineID] = append(ret[machineID], tconRef)
+	}
+	return ret
+}
+
+func (smbinfo *SMBInfo) MapServiceToMachines() map[string]map[string]int {
+	ret := map[string]map[string]int{}
+	for _, tcon := range smbinfo.smbstat.TCons {
+		serviceID := tcon.Service
+		machineID := tcon.Machine
+		sub, found := ret[serviceID]
+		if !found {
+			ret[serviceID] = map[string]int{machineID: 1}
+		} else {
+			sub[machineID]++
+		}
+	}
+	return ret
+}

--- a/internal/metrics/smbstatus.go
+++ b/internal/metrics/smbstatus.go
@@ -115,6 +115,15 @@ func LocateSMBStatus() (string, error) {
 	return "", errors.New("failed to locate smbstatus")
 }
 
+// RunSMBStatus executes 'smbstatus --json' on host machine
+func RunSMBStatus() (*SMBStatus, error) {
+	dat, err := executeSMBStatusCommand("--json")
+	if err != nil {
+		return &SMBStatus{}, err
+	}
+	return parseSMBStatus(dat)
+}
+
 // RunSMBStatusVersion executes 'smbstatus --version' on host container
 func RunSMBStatusVersion() (string, error) {
 	ver, err := executeSMBStatusCommand("--version")

--- a/internal/metrics/smbstatus.go
+++ b/internal/metrics/smbstatus.go
@@ -68,8 +68,8 @@ type SMBStatusFileID struct {
 	Extid int32 `json:"extid"`
 }
 
-// SMBStatusLockedFile represents a locked-file output field
-type SMBStatusLockedFile struct {
+// SMBStatusOpenFile represents a open-file output field
+type SMBStatusOpenFile struct {
 	ServicePath       string          `json:"service_path"`
 	Filename          string          `json:"filename"`
 	FileID            SMBStatusFileID `json:"fileid"`
@@ -78,20 +78,20 @@ type SMBStatusLockedFile struct {
 
 // SMBStatus represents output of 'smbstatus --json'
 type SMBStatus struct {
-	Timestamp   string                         `json:"timestamp"`
-	Version     string                         `json:"version"`
-	SmbConf     string                         `json:"smb_conf"`
-	Sessions    map[string]SMBStatusSession    `json:"sessions"`
-	TCons       map[string]SMBStatusTreeCon    `json:"tcons"`
-	LockedFiles map[string]SMBStatusLockedFile `json:"locked_files"`
+	Timestamp string                       `json:"timestamp"`
+	Version   string                       `json:"version"`
+	SmbConf   string                       `json:"smb_conf"`
+	Sessions  map[string]SMBStatusSession  `json:"sessions"`
+	TCons     map[string]SMBStatusTreeCon  `json:"tcons"`
+	OpenFiles map[string]SMBStatusOpenFile `json:"open_files"`
 }
 
 // SMBStatusLocks represents output of 'smbstatus -L --json'
 type SMBStatusLocks struct {
-	Timestamp string                         `json:"timestamp"`
-	Version   string                         `json:"version"`
-	SmbConf   string                         `json:"smb_conf"`
-	OpenFiles map[string]SMBStatusLockedFile `json:"open_files"`
+	Timestamp string                       `json:"timestamp"`
+	Version   string                       `json:"version"`
+	SmbConf   string                       `json:"smb_conf"`
+	OpenFiles map[string]SMBStatusOpenFile `json:"open_files"`
 }
 
 // LocateSMBStatus finds the local executable of 'smbstatus' on host.
@@ -155,16 +155,16 @@ func parseSMBStatusTreeCons(dat string) ([]SMBStatusTreeCon, error) {
 }
 
 // RunSMBStatusLocks executes 'smbstatus --locks --json' on host
-func RunSMBStatusLocks() ([]SMBStatusLockedFile, error) {
+func RunSMBStatusLocks() ([]SMBStatusOpenFile, error) {
 	dat, err := executeSMBStatusCommand("--locks --json")
 	if err != nil {
-		return []SMBStatusLockedFile{}, err
+		return []SMBStatusOpenFile{}, err
 	}
 	return parseSMBStatusLockedFiles(dat)
 }
 
-func parseSMBStatusLockedFiles(dat string) ([]SMBStatusLockedFile, error) {
-	lockedFiles := []SMBStatusLockedFile{}
+func parseSMBStatusLockedFiles(dat string) ([]SMBStatusOpenFile, error) {
+	lockedFiles := []SMBStatusOpenFile{}
 	res, err := parseSMBStatusLocks(dat)
 	if err != nil {
 		return lockedFiles, err
@@ -230,12 +230,12 @@ func parseSMBStatusLocks(data string) (*SMBStatusLocks, error) {
 // NewSMBStatus returns non-populated SMBStatus object
 func NewSMBStatus() *SMBStatus {
 	smbStatus := SMBStatus{
-		Timestamp:   "",
-		Version:     "",
-		SmbConf:     "",
-		Sessions:    map[string]SMBStatusSession{},
-		TCons:       map[string]SMBStatusTreeCon{},
-		LockedFiles: map[string]SMBStatusLockedFile{},
+		Timestamp: "",
+		Version:   "",
+		SmbConf:   "",
+		Sessions:  map[string]SMBStatusSession{},
+		TCons:     map[string]SMBStatusTreeCon{},
+		OpenFiles: map[string]SMBStatusOpenFile{},
 	}
 	return &smbStatus
 }

--- a/internal/metrics/smbstatus.go
+++ b/internal/metrics/smbstatus.go
@@ -205,9 +205,9 @@ func executeCommand(command string, arg ...string) (string, error) {
 // parseSMBStatus parses to output of 'smbstatus --json' into internal
 // representation.
 func parseSMBStatus(data string) (*SMBStatus, error) {
-	res := SMBStatus{}
-	err := json.Unmarshal([]byte(data), &res)
-	return &res, err
+	res := NewSMBStatus()
+	err := json.Unmarshal([]byte(data), res)
+	return res, err
 }
 
 // parseSMBStatusLocks parses to output of 'smbstatus --locks --json' into
@@ -216,4 +216,17 @@ func parseSMBStatusLocks(data string) (*SMBStatusLocks, error) {
 	res := SMBStatusLocks{}
 	err := json.Unmarshal([]byte(data), &res)
 	return &res, err
+}
+
+// NewSMBStatus returns non-populated SMBStatus object
+func NewSMBStatus() *SMBStatus {
+	smbStatus := SMBStatus{
+		Timestamp:   "",
+		Version:     "",
+		SmbConf:     "",
+		Sessions:    map[string]SMBStatusSession{},
+		TCons:       map[string]SMBStatusTreeCon{},
+		LockedFiles: map[string]SMBStatusLockedFile{},
+	}
+	return &smbStatus
 }

--- a/internal/metrics/smbstatus_test.go
+++ b/internal/metrics/smbstatus_test.go
@@ -147,7 +147,7 @@ var (
 		}
 	  }
 	},
-	"locked_files": {
+	"open_files": {
 	  "/home/janger/testfolder/hallo": {
 		"service_path": "/home/janger/testfolder",
 		"filename": "hallo",
@@ -267,7 +267,7 @@ var (
 		}
 	  }
 	},
-	"locked_files": {
+	"open_files": {
 	  "/mnt/96dd85fd-6c60-409c-bc1c-15f98eb358ee/a/y": {
 		"service_path": "/mnt/96dd85fd-6c60-409c-bc1c-15f98eb358ee",
 		"filename": "a/y",
@@ -584,11 +584,11 @@ func TestParseSMBStatusAll(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(dat.Sessions), 1)
 	assert.Equal(t, len(dat.TCons), 1)
-	assert.Equal(t, len(dat.LockedFiles), 1)
+	assert.Equal(t, len(dat.OpenFiles), 1)
 
 	dat2, err := parseSMBStatus(smbstatusOutput4)
 	assert.NoError(t, err)
-	assert.Equal(t, len(dat2.LockedFiles), 2)
+	assert.Equal(t, len(dat2.OpenFiles), 2)
 }
 
 func TestParseSMBStatusLocks(t *testing.T) {


### PR DESCRIPTION
Provides SMBInfo which serves as glue logic between raw `smbstatus` and exported metrics. Any logic (e.g., using in-memory re-mapping) is done via `smbinfo` layer.