### PR TITLE
metrics extended

### DIFF
--- a/internal/metrics/collectors.go
+++ b/internal/metrics/collectors.go
@@ -88,12 +88,14 @@ func (col *smbActivityCollector) Collect(ch chan<- prometheus.Metric) {
 	totalTreeCons := 0
 	totalConnectedUsers := 0
 	totalOpenFiles := 0
+	totalOpenFilesAccessRW := 0
 	smbInfo, err := NewUpdatedSMBInfo()
 	if err == nil {
 		totalSessions = smbInfo.TotalSessions()
 		totalTreeCons = smbInfo.TotalTreeCons()
 		totalConnectedUsers = smbInfo.TotalConnectedUsers()
 		totalOpenFiles = smbInfo.TotalOpenFiles()
+		totalOpenFilesAccessRW = smbInfo.TotalOpenFilesAccessRW()
 	}
 	ch <- prometheus.MustNewConstMetric(col.dsc[0],
 		prometheus.GaugeValue, float64(totalSessions))
@@ -106,6 +108,9 @@ func (col *smbActivityCollector) Collect(ch chan<- prometheus.Metric) {
 
 	ch <- prometheus.MustNewConstMetric(col.dsc[3],
 		prometheus.GaugeValue, float64(totalOpenFiles))
+
+	ch <- prometheus.MustNewConstMetric(col.dsc[4],
+		prometheus.GaugeValue, float64(totalOpenFilesAccessRW))
 }
 
 func (sme *smbMetricsExporter) newSMBActivityCollector() prometheus.Collector {
@@ -130,6 +135,11 @@ func (sme *smbMetricsExporter) newSMBActivityCollector() prometheus.Collector {
 		prometheus.NewDesc(
 			collectorName("openfiles", "total"),
 			"Number of currently open files",
+			[]string{}, nil),
+
+		prometheus.NewDesc(
+			collectorName("openfiles", "access_rw"),
+			"Number of open files with read-write access mode",
 			[]string{}, nil),
 	}
 	return col

--- a/internal/metrics/smbinfo.go
+++ b/internal/metrics/smbinfo.go
@@ -35,7 +35,15 @@ func (smbinfo *SMBInfo) TotalSessions() int {
 }
 
 func (smbinfo *SMBInfo) TotalTreeCons() int {
-	return len(smbinfo.smbstat.TCons)
+	total := 0
+	for _, tcon := range smbinfo.smbstat.TCons {
+		serviceID := tcon.Service
+		if isInternalServiceID(serviceID) {
+			continue
+		}
+		total++
+	}
+	return total
 }
 
 func (smbinfo *SMBInfo) TotalOpenFiles() int {
@@ -79,6 +87,9 @@ func (smbinfo *SMBInfo) MapServiceToTreeCons() map[string][]*SMBStatusTreeCon {
 	ret := map[string][]*SMBStatusTreeCon{}
 	for _, tcon := range smbinfo.smbstat.TCons {
 		serviceID := tcon.Service
+		if isInternalServiceID(serviceID) {
+			continue
+		}
 		tconRef := &tcon
 		ret[serviceID] = append(ret[serviceID], tconRef)
 	}
@@ -88,6 +99,10 @@ func (smbinfo *SMBInfo) MapServiceToTreeCons() map[string][]*SMBStatusTreeCon {
 func (smbinfo *SMBInfo) MapMachineToTreeCons() map[string][]*SMBStatusTreeCon {
 	ret := map[string][]*SMBStatusTreeCon{}
 	for _, tcon := range smbinfo.smbstat.TCons {
+		serviceID := tcon.Service
+		if isInternalServiceID(serviceID) {
+			continue
+		}
 		machineID := tcon.Machine
 		tconRef := &tcon
 		ret[machineID] = append(ret[machineID], tconRef)
@@ -99,6 +114,9 @@ func (smbinfo *SMBInfo) MapServiceToMachines() map[string]map[string]int {
 	ret := map[string]map[string]int{}
 	for _, tcon := range smbinfo.smbstat.TCons {
 		serviceID := tcon.Service
+		if isInternalServiceID(serviceID) {
+			continue
+		}
 		machineID := tcon.Machine
 		sub, found := ret[serviceID]
 		if !found {
@@ -114,6 +132,9 @@ func (smbinfo *SMBInfo) MapMachineToServies() map[string]map[string]int {
 	ret := map[string]map[string]int{}
 	for _, tcon := range smbinfo.smbstat.TCons {
 		serviceID := tcon.Service
+		if isInternalServiceID(serviceID) {
+			continue
+		}
 		machineID := tcon.Machine
 		sub, found := ret[machineID]
 		if !found {
@@ -123,4 +144,8 @@ func (smbinfo *SMBInfo) MapMachineToServies() map[string]map[string]int {
 		}
 	}
 	return ret
+}
+
+func isInternalServiceID(serviceID string) bool {
+	return serviceID == "IPC$"
 }

--- a/internal/metrics/smbinfo.go
+++ b/internal/metrics/smbinfo.go
@@ -2,6 +2,8 @@
 
 package metrics
 
+import "strings"
+
 // SMBInfo provides a bridge layer between raw smbstatus info and exported
 // metric counters. It also implements the more complex logic which requires in
 // memory re-mapping of the low-level information (e.g., stats by machine/user).
@@ -38,6 +40,18 @@ func (smbinfo *SMBInfo) TotalTreeCons() int {
 
 func (smbinfo *SMBInfo) TotalOpenFiles() int {
 	return len(smbinfo.smbstat.OpenFiles)
+}
+
+func (smbinfo *SMBInfo) TotalOpenFilesAccessRW() int {
+	total := 0
+	for _, openf := range smbinfo.smbstat.OpenFiles {
+		for _, opens := range openf.Opens {
+			if strings.Contains(opens.AccessMask.Text, "RW") {
+				total++
+			}
+		}
+	}
+	return total
 }
 
 func (smbinfo *SMBInfo) TotalConnectedUsers() int {

--- a/internal/metrics/smbinfo.go
+++ b/internal/metrics/smbinfo.go
@@ -109,3 +109,18 @@ func (smbinfo *SMBInfo) MapServiceToMachines() map[string]map[string]int {
 	}
 	return ret
 }
+
+func (smbinfo *SMBInfo) MapMachineToServies() map[string]map[string]int {
+	ret := map[string]map[string]int{}
+	for _, tcon := range smbinfo.smbstat.TCons {
+		serviceID := tcon.Service
+		machineID := tcon.Machine
+		sub, found := ret[machineID]
+		if !found {
+			ret[machineID] = map[string]int{serviceID: 1}
+		} else {
+			sub[serviceID]++
+		}
+	}
+	return ret
+}

--- a/internal/metrics/smbstatus.go
+++ b/internal/metrics/smbstatus.go
@@ -70,10 +70,70 @@ type SMBStatusFileID struct {
 
 // SMBStatusOpenFile represents a open-file output field
 type SMBStatusOpenFile struct {
-	ServicePath       string          `json:"service_path"`
-	Filename          string          `json:"filename"`
-	FileID            SMBStatusFileID `json:"fileid"`
-	NumPendingDeletes int             `json:"num_pending_deletes"`
+	ServicePath       string                       `json:"service_path"`
+	Filename          string                       `json:"filename"`
+	FileID            SMBStatusFileID              `json:"fileid"`
+	NumPendingDeletes int                          `json:"num_pending_deletes"`
+	Opens             map[string]SMBStatusOpenInfo `json:"opens"`
+}
+
+// SMBStatusOpenInfo represents a single entry open_files/opens output field
+type SMBStatusOpenInfo struct {
+	UID         int                     `json:"uid"`
+	ShareFileID string                  `json:"share_file_id"`
+	OpenedAt    string                  `json:"opened_at"`
+	ShareMode   SMBStatusOpenShareMode  `json:"sharemode"`
+	AccessMask  SMBStatusOpenAccessMask `json:"access_mask"`
+	OpLock      SMBStatusOpenOpLock     `json:"oplock"`
+	Lease       SMBStatusOpenLease      `json:"lease"`
+}
+
+// SMBStatusOpenShareMode represents a open file share-mode entry
+type SMBStatusOpenShareMode struct {
+	Read   bool   `json:"READ"`
+	Write  bool   `json:"WRITE"`
+	Delete bool   `json:"DELETE"`
+	Text   string `json:"text"`
+	Hex    string `json:"hex"`
+}
+
+// SMBStatusOpenShareMode represents a open file access-mask entry
+type SMBStatusOpenAccessMask struct {
+	ReadData             bool   `json:"READ_DATA"`
+	WriteData            bool   `json:"WRITE_DATA"`
+	AppendData           bool   `json:"APPEND_DATA"`
+	ReadEA               bool   `json:"READ_EA"`
+	WriteEA              bool   `json:"WRITE_EA"`
+	Execute              bool   `json:"EXECUTE"`
+	ReadAttributes       bool   `json:"READ_ATTRIBUTES"`
+	WriteAttributes      bool   `json:"WRITE_ATTRIBUTES"`
+	DeleteChild          bool   `json:"DELETE_CHILD"`
+	Delete               bool   `json:"DELETE"`
+	ReadControl          bool   `json:"READ_CONTROL"`
+	WriteDAC             bool   `json:"WRITE_DAC"`
+	Synchronize          bool   `json:"SYNCHRONIZE"`
+	AccessSystemSecurity bool   `json:"ACCESS_SYSTEM_SECURITY"`
+	Text                 string `json:"text"`
+	Hex                  string `json:"hex"`
+}
+
+// SMBStatusOpenOplock represents an open file operation-lock entry
+type SMBStatusOpenOpLock struct {
+	Exclusive bool   `json:"EXCLUSIVE"`
+	Batch     bool   `json:"BATCH"`
+	LevelII   bool   `json:"LEVEL_II"`
+	Lease     bool   `json:"LEASE"`
+	Text      string `json:"text"`
+}
+
+// SMBStatusOpenLease represents an open file lease entry
+type SMBStatusOpenLease struct {
+	LeaseKey string `json:"lease_key"`
+	Read     bool   `json:"READ"`
+	Write    bool   `json:"WRITE"`
+	Handle   bool   `json:"HANDLE"`
+	Text     string `json:"text"`
+	Hex      string `json:"hex"`
 }
 
 // SMBStatus represents output of 'smbstatus --json'

--- a/internal/metrics/smbstatus_test.go
+++ b/internal/metrics/smbstatus_test.go
@@ -166,7 +166,7 @@ var (
 			  "unique_id": "10756714984493602300"
 			},
 			"uid": 1000,
-			"share_file_id": 2,
+			"share_file_id": "2",
 			"sharemode": {
 			  "hex": "0x00000003",
 			  "NONE": false,
@@ -286,7 +286,7 @@ var (
 			  "unique_id": "7364797719700910696"
 			},
 			"uid": 1000,
-			"share_file_id": 61,
+			"share_file_id": "61",
 			"sharemode": {
 			  "hex": "0x00000007",
 			  "NONE": false,
@@ -322,19 +322,12 @@ var (
 			},
 			"oplock": {
 			  "EXCLUSIVE": false,
-			  "BATCH": false,
+			  "BATCH": true,
 			  "LEVEL_II": false,
-			  "LEASE": true,
-			  "text": "LEASE(RWH)"
+			  "LEASE": false,
+			  "text": "BATCH"
 			},
-			"lease": {
-			  "lease_key": "ac1cf117-4ac6-b543-8bc8-597d795e8546",
-			  "hex": "0x00000007",
-			  "READ": true,
-			  "WRITE": true,
-			  "HANDLE": true,
-			  "text": "RWH"
-			},
+			"lease": {},
 			"connected_at": "2022-07-20T12:06:29+0000"
 		  }
 		}
@@ -357,7 +350,7 @@ var (
 			  "unique_id": "7364797719700910696"
 			},
 			"uid": 1000,
-			"share_file_id": 65,
+			"share_file_id": "65",
 			"sharemode": {
 			  "hex": "0x00000007",
 			  "NONE": false,
@@ -393,19 +386,12 @@ var (
 			},
 			"oplock": {
 			  "EXCLUSIVE": false,
-			  "BATCH": false,
+			  "BATCH": true,
 			  "LEVEL_II": false,
 			  "LEASE": true,
-			  "text": "LEASE(RWH)"
+			  "text": "BATCH"
 			},
-			"lease": {
-			  "lease_key": "a110aee8-2bfa-2349-b148-22a018a2e061",
-			  "hex": "0x00000007",
-			  "READ": true,
-			  "WRITE": true,
-			  "HANDLE": true,
-			  "text": "RWH"
-			},
+			"lease": {},
 			"connected_at": "2022-07-20T12:06:42+0000"
 		  }
 		}
@@ -414,7 +400,7 @@ var (
   }
   `
 
-	smbstatusLocksOutput = `
+	smbstatusOutput5 = `
   {
 	"timestamp": "2024-04-14T14:53:34.901974+0300",
 	"version": "4.21.0pre1-GIT-58a018fb7ad",
@@ -478,7 +464,6 @@ var (
 		  "LEASE": false,
 		  "text": "BATCH"
 		},
-		"lease": {},
 		"opened_at": "2024-04-14T14:53:15.569085+03:00"
 	      }
 	    }
@@ -535,13 +520,12 @@ var (
 		  "text": "RW"
 		},
 		"oplock": {
-		  "EXCLUSIVE": true,
-		  "BATCH": true,
-		  "LEVEL_II": false,
+		  "EXCLUSIVE": false,
+		  "BATCH": false,
+		  "LEVEL_II": true,
 		  "LEASE": false,
 		  "text": "BATCH"
 		},
-		"lease": {},
 		"opened_at": "2024-04-14T14:53:32.258325+03:00"
 	      }
 	    }
@@ -549,6 +533,411 @@ var (
 	}
       }
   `
+
+	smbstatusOutput6 = `
+{
+  "timestamp": "2024-07-04T13:04:45.910759+0300",
+  "version": "4.21.0pre1-GIT-a5c7776b2f9",
+  "smb_conf": "//etc/samba/smb.conf",
+  "sessions": {
+    "2211197710": {
+      "session_id": "2211197710",
+      "server_id": {
+        "pid": "34128",
+        "task_id": "0",
+        "vnn": "4294967295",
+        "unique_id": "16540149349904229747"
+      },
+      "uid": 1111,
+      "gid": 1111,
+      "username": "testuser",
+      "groupname": "testuser",
+      "creation_time": "2024-07-04T12:44:14.413940+03:00",
+      "expiration_time": "30828-09-14T05:48:05.477581+03:00",
+      "auth_time": "2024-07-04T12:44:14.418769+03:00",
+      "remote_machine": "192.168.122.83",
+      "hostname": "ipv4:192.168.122.83:56892",
+      "session_dialect": "SMB2_02",
+      "client_guid": "00000000-0000-0000-0000-000000000000",
+      "encryption": {
+        "cipher": "-",
+        "degree": "none"
+      },
+      "signing": {
+        "cipher": "-",
+        "degree": "none"
+      },
+      "channels": {
+        "1": {
+          "channel_id": "1",
+          "creation_time": "2024-07-04T12:44:14.413940+03:00",
+          "local_address": "ipv4:192.168.122.119:445",
+          "remote_address": "ipv4:192.168.122.83:56892"
+        }
+      }
+    },
+    "664362732": {
+      "session_id": "664362732",
+      "server_id": {
+        "pid": "34156",
+        "task_id": "0",
+        "vnn": "4294967295",
+        "unique_id": "10342000937013985296"
+      },
+      "uid": 1111,
+      "gid": 1111,
+      "username": "testuser",
+      "groupname": "testuser",
+      "creation_time": "2024-07-04T12:48:20.117703+03:00",
+      "expiration_time": "30828-09-14T05:48:05.477581+03:00",
+      "auth_time": "2024-07-04T12:48:20.124245+03:00",
+      "remote_machine": "192.168.122.235",
+      "hostname": "ipv4:192.168.122.235:34092",
+      "session_dialect": "SMB2_02",
+      "client_guid": "00000000-0000-0000-0000-000000000000",
+      "encryption": {
+        "cipher": "-",
+        "degree": "none"
+      },
+      "signing": {
+        "cipher": "-",
+        "degree": "none"
+      },
+      "channels": {
+        "1": {
+          "channel_id": "1",
+          "creation_time": "2024-07-04T12:48:20.117703+03:00",
+          "local_address": "ipv4:192.168.122.119:445",
+          "remote_address": "ipv4:192.168.122.235:34092"
+        }
+      }
+    }
+  },
+  "tcons": {
+    "2459296875": {
+      "service": "IPC$",
+      "server_id": {
+        "pid": "34156",
+        "task_id": "0",
+        "vnn": "4294967295",
+        "unique_id": "10342000937013985296"
+      },
+      "tcon_id": "2459296875",
+      "session_id": "664362732",
+      "machine": "192.168.122.235",
+      "connected_at": "2024-07-04T12:48:20.129126+03:00",
+      "encryption": {
+        "cipher": "-",
+        "degree": "none"
+      },
+      "signing": {
+        "cipher": "-",
+        "degree": "none"
+      }
+    },
+    "1357200611": {
+      "service": "smbshare",
+      "server_id": {
+        "pid": "34156",
+        "task_id": "0",
+        "vnn": "4294967295",
+        "unique_id": "10342000937013985296"
+      },
+      "tcon_id": "1357200611",
+      "session_id": "664362732",
+      "machine": "192.168.122.235",
+      "connected_at": "2024-07-04T12:48:20.130103+03:00",
+      "encryption": {
+        "cipher": "-",
+        "degree": "none"
+      },
+      "signing": {
+        "cipher": "-",
+        "degree": "none"
+      }
+    },
+    "2373869966": {
+      "service": "smbshare",
+      "server_id": {
+        "pid": "34128",
+        "task_id": "0",
+        "vnn": "4294967295",
+        "unique_id": "16540149349904229747"
+      },
+      "tcon_id": "2373869966",
+      "session_id": "2211197710",
+      "machine": "192.168.122.83",
+      "connected_at": "2024-07-04T12:44:14.424733+03:00",
+      "encryption": {
+        "cipher": "-",
+        "degree": "none"
+      },
+      "signing": {
+        "cipher": "-",
+        "degree": "none"
+      }
+    },
+    "2758374422": {
+      "service": "IPC$",
+      "server_id": {
+        "pid": "34128",
+        "task_id": "0",
+        "vnn": "4294967295",
+        "unique_id": "16540149349904229747"
+      },
+      "tcon_id": "2758374422",
+      "session_id": "2211197710",
+      "machine": "192.168.122.83",
+      "connected_at": "2024-07-04T12:44:14.423739+03:00",
+      "encryption": {
+        "cipher": "-",
+        "degree": "none"
+      },
+      "signing": {
+        "cipher": "-",
+        "degree": "none"
+      }
+    }
+  },
+  "open_files": {
+    "/A/b": {
+      "service_path": "/",
+      "filename": "A/b",
+      "fileid": {
+        "devid": -2,
+        "inode": 1099512325566,
+        "extid": 0
+      },
+      "num_pending_deletes": 0,
+      "opens": {
+        "34156/114": {
+          "server_id": {
+            "pid": "34156",
+            "task_id": "0",
+            "vnn": "4294967295",
+            "unique_id": "10342000937013985296"
+          },
+          "uid": 1111,
+          "share_file_id": "114",
+          "sharemode": {
+            "hex": "0x00000007",
+            "READ": true,
+            "WRITE": true,
+            "DELETE": true,
+            "text": "RWD"
+          },
+          "access_mask": {
+            "hex": "0x00120089",
+            "READ_DATA": true,
+            "WRITE_DATA": false,
+            "APPEND_DATA": false,
+            "READ_EA": true,
+            "WRITE_EA": false,
+            "EXECUTE": false,
+            "READ_ATTRIBUTES": true,
+            "WRITE_ATTRIBUTES": false,
+            "DELETE_CHILD": false,
+            "DELETE": false,
+            "READ_CONTROL": true,
+            "WRITE_DAC": false,
+            "SYNCHRONIZE": true,
+            "ACCESS_SYSTEM_SECURITY": false,
+            "text": "R"
+          },
+          "caching": {
+            "READ": true,
+            "WRITE": false,
+            "HANDLE": false,
+            "hex": "0x00000001",
+            "text": "R"
+          },
+          "oplock": {
+            "EXCLUSIVE": false,
+            "BATCH": false,
+            "LEVEL_II": false,
+            "LEASE": true,
+            "text": "LEASE"
+          },
+          "lease": {
+            "lease_key": "272e4282-36e6-11ef-8a34-309c2337f855",
+            "hex": "0x00000005",
+            "READ": true,
+            "WRITE": true,
+            "HANDLE": false,
+            "text": "LEASE(RW)"
+          },
+          "opened_at": "2024-07-04T13:02:41.967466+03:00"
+        },
+        "34128/309": {
+          "server_id": {
+            "pid": "34128",
+            "task_id": "0",
+            "vnn": "4294967295",
+            "unique_id": "16540149349904229747"
+          },
+          "uid": 1111,
+          "share_file_id": "309",
+          "sharemode": {
+            "hex": "0x00000007",
+            "READ": true,
+            "WRITE": true,
+            "DELETE": true,
+            "text": "RWD"
+          },
+          "access_mask": {
+            "hex": "0x0012019f",
+            "READ_DATA": true,
+            "WRITE_DATA": true,
+            "APPEND_DATA": true,
+            "READ_EA": true,
+            "WRITE_EA": true,
+            "EXECUTE": false,
+            "READ_ATTRIBUTES": true,
+            "WRITE_ATTRIBUTES": true,
+            "DELETE_CHILD": false,
+            "DELETE": false,
+            "READ_CONTROL": true,
+            "WRITE_DAC": false,
+            "SYNCHRONIZE": true,
+            "ACCESS_SYSTEM_SECURITY": false,
+            "text": "RW"
+          },
+          "caching": {
+            "READ": true,
+            "WRITE": false,
+            "HANDLE": false,
+            "hex": "0x00000001",
+            "text": "R"
+          },
+          "oplock": {
+            "EXCLUSIVE": false,
+            "BATCH": false,
+            "LEVEL_II": true,
+            "LEASE": false,
+            "text": "LEVEL_II"
+          },
+          "lease": {},
+          "opened_at": "2024-07-04T13:04:05.727421+03:00"
+        }
+      }
+    },
+    "/A/a": {
+      "service_path": "/",
+      "filename": "A/a",
+      "fileid": {
+        "devid": -2,
+        "inode": 1099512188451,
+        "extid": 0
+      },
+      "num_pending_deletes": 0,
+      "opens": {
+        "34156/110": {
+          "server_id": {
+            "pid": "34156",
+            "task_id": "0",
+            "vnn": "4294967295",
+            "unique_id": "10342000937013985296"
+          },
+          "uid": 1111,
+          "share_file_id": "110",
+          "sharemode": {
+            "hex": "0x00000007",
+            "READ": true,
+            "WRITE": true,
+            "DELETE": true,
+            "text": "RWD"
+          },
+          "access_mask": {
+            "hex": "0x0012019f",
+            "READ_DATA": true,
+            "WRITE_DATA": true,
+            "APPEND_DATA": true,
+            "READ_EA": true,
+            "WRITE_EA": true,
+            "EXECUTE": false,
+            "READ_ATTRIBUTES": true,
+            "WRITE_ATTRIBUTES": true,
+            "DELETE_CHILD": false,
+            "DELETE": false,
+            "READ_CONTROL": true,
+            "WRITE_DAC": false,
+            "SYNCHRONIZE": true,
+            "ACCESS_SYSTEM_SECURITY": false,
+            "text": "RW"
+          },
+          "caching": {
+            "READ": true,
+            "WRITE": false,
+            "HANDLE": false,
+            "hex": "0x00000001",
+            "text": "R"
+          },
+          "oplock": {
+            "EXCLUSIVE": false,
+            "BATCH": false,
+            "LEVEL_II": true,
+            "LEASE": false,
+            "text": "LEVEL_II"
+          },
+          "lease": {},
+          "opened_at": "2024-07-04T13:02:18.430418+03:00"
+        },
+        "34128/303": {
+          "server_id": {
+            "pid": "34128",
+            "task_id": "0",
+            "vnn": "4294967295",
+            "unique_id": "16540149349904229747"
+          },
+          "uid": 1111,
+          "share_file_id": "303",
+          "sharemode": {
+            "hex": "0x00000007",
+            "READ": true,
+            "WRITE": true,
+            "DELETE": true,
+            "text": "RWD"
+          },
+          "access_mask": {
+            "hex": "0x0012019f",
+            "READ_DATA": true,
+            "WRITE_DATA": true,
+            "APPEND_DATA": true,
+            "READ_EA": true,
+            "WRITE_EA": true,
+            "EXECUTE": false,
+            "READ_ATTRIBUTES": true,
+            "WRITE_ATTRIBUTES": true,
+            "DELETE_CHILD": false,
+            "DELETE": false,
+            "READ_CONTROL": true,
+            "WRITE_DAC": false,
+            "SYNCHRONIZE": true,
+            "ACCESS_SYSTEM_SECURITY": false,
+            "text": "RW"
+          },
+          "caching": {
+            "READ": true,
+            "WRITE": false,
+            "HANDLE": false,
+            "hex": "0x00000001",
+            "text": "R"
+          },
+          "oplock": {
+            "EXCLUSIVE": false,
+            "BATCH": false,
+            "LEVEL_II": true,
+            "LEASE": false,
+            "text": "LEVEL_II"
+          },
+          "lease": {},
+          "opened_at": "2024-07-04T13:02:04.739655+03:00"
+        }
+      }
+    }
+  }
+}
+`
 )
 
 //revive:enable line-length-limit
@@ -592,7 +981,7 @@ func TestParseSMBStatusAll(t *testing.T) {
 }
 
 func TestParseSMBStatusLocks(t *testing.T) {
-	locks, err := parseSMBStatusLockedFiles(smbstatusLocksOutput)
+	locks, err := parseSMBStatusLockedFiles(smbstatusOutput5)
 	assert.NoError(t, err)
 	assert.Equal(t, len(locks), 2)
 	lock1 := locks[0]
@@ -601,4 +990,49 @@ func TestParseSMBStatusLocks(t *testing.T) {
 	lock2 := locks[1]
 	assert.Equal(t, lock2.FileID.Inode, int64(52))
 	assert.Equal(t, lock2.NumPendingDeletes, 2)
+}
+
+func TestParseSMBStatusOpenFiles(t *testing.T) {
+	status, err := parseSMBStatus(smbstatusOutput6)
+	assert.NoError(t, err)
+	assert.Equal(t, len(status.OpenFiles), 2)
+	openFileAa := status.OpenFiles["/A/a"]
+	assert.Equal(t, len(openFileAa.Opens), 2)
+	for _, open := range openFileAa.Opens {
+		oplock := open.OpLock
+		lease := open.Lease
+		assert.Equal(t, oplock.Batch, false)
+		assert.Equal(t, oplock.LevelII, true)
+		assert.Equal(t, oplock.Text, "LEVEL_II")
+		assert.Equal(t, oplock.Exclusive, false)
+		assert.Equal(t, lease.Handle, false)
+		assert.Equal(t, lease.Read, false)
+		assert.Equal(t, lease.Write, false)
+		assert.Equal(t, lease.Text, "")
+	}
+	openFileAb := status.OpenFiles["/A/b"]
+	assert.Equal(t, len(openFileAb.Opens), 2)
+	for _, open := range openFileAb.Opens {
+		oplock := open.OpLock
+		lease := open.Lease
+		if oplock.Lease {
+			assert.Equal(t, oplock.Batch, false)
+			assert.Equal(t, oplock.LevelII, false)
+			assert.Equal(t, oplock.Text, "LEASE")
+			assert.Equal(t, oplock.Exclusive, false)
+			assert.Equal(t, lease.Handle, false)
+			assert.Equal(t, lease.Read, true)
+			assert.Equal(t, lease.Write, true)
+			assert.Equal(t, lease.Text, "LEASE(RW)")
+		} else {
+			assert.Equal(t, oplock.Batch, false)
+			assert.Equal(t, oplock.LevelII, true)
+			assert.Equal(t, oplock.Text, "LEVEL_II")
+			assert.Equal(t, oplock.Exclusive, false)
+			assert.Equal(t, lease.Handle, false)
+			assert.Equal(t, lease.Read, false)
+			assert.Equal(t, lease.Write, false)
+			assert.Equal(t, lease.Text, "")
+		}
+	}
 }


### PR DESCRIPTION
Provide extra-fine metrics information. In particular,. parse the `open_files` section in `smbstatus --json` and provide more metrics on open files.