### PR TITLE
Re-define default exporter port 9922

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ FROM quay.io/samba.org/samba-server
 COPY --from=builder /workspace/smbmetrics /bin/smbmetrics
 
 ENTRYPOINT ["/bin/smbmetrics"]
-EXPOSE 8080
+EXPOSE 9922

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,7 +48,7 @@ func main() {
 	}
 	log.Info("Located smbstatus", "path", loc, "version", ver)
 
-	err = metrics.RunSmbMetricsExporter(log)
+	err = metrics.RunSmbMetricsExporter(log, metrics.DefaultMetricsPort)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	goruntime "runtime"
 
+	"github.com/spf13/pflag"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/samba-in-kubernetes/smbmetrics/internal/metrics"
@@ -23,6 +24,11 @@ func init() {
 }
 
 func main() {
+	var port int
+	pflag.IntVar(&port, "port", metrics.DefaultMetricsPort,
+		"Prometheus metrics-exporter port number")
+	pflag.Parse()
+
 	log := zap.New(zap.UseDevMode(true))
 	log.Info("Initializing smbmetrics",
 		"ProgramName", os.Args[0],
@@ -48,7 +54,7 @@ func main() {
 	}
 	log.Info("Located smbstatus", "path", loc, "version", ver)
 
-	err = metrics.RunSmbMetricsExporter(log, metrics.DefaultMetricsPort)
+	err = metrics.RunSmbMetricsExporter(log, port)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/go-logr/logr v0.4.0
 	github.com/prometheus/client_golang v1.11.1
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2

--- a/internal/metrics/exporter.go
+++ b/internal/metrics/exporter.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	// DefaultMetricsPort is the default port used to export prometheus metrics
-	DefaultMetricsPort = int(8080)
+	DefaultMetricsPort = int(9922)
 	// DefaultMetricsPath is the default HTTP path to export prometheus metrics
 	DefaultMetricsPath = "/metrics"
 )

--- a/internal/metrics/exporter.go
+++ b/internal/metrics/exporter.go
@@ -63,8 +63,11 @@ func (sme *smbMetricsExporter) serve() error {
 
 // RunSmbMetricsExporter executes an HTTP server and exports SMB metrics to
 // Prometheus.
-func RunSmbMetricsExporter(log logr.Logger) error {
-	sme := newSmbMetricsExporter(log, DefaultMetricsPort)
+func RunSmbMetricsExporter(log logr.Logger, port int) error {
+	if port <= 0 {
+		port = DefaultMetricsPort
+	}
+	sme := newSmbMetricsExporter(log, port)
 	err := sme.init()
 	if err != nil {
 		return err


### PR DESCRIPTION
Use default Samba-exporter port value from (same as NFS-Ganesha):

https://github.com/prometheus/prometheus/wiki/Default-port-allocations

Allow override via command-line flag.