### PR TITLE
improved performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ $ curl --request GET "http://localhost:9922/metrics"
 | `smb_sessions_total`      | Number of active SMB sessions                    |
 | `smb_tcon_total`          | Number of active SMB tree-connections            |
 | `smb_users_total`         | Number of connected users                        |
-| `smb_openfiles_total`     | Number of currently open files                   |
-| `smb_openfiles_access_rw` | Open files with `"RW"` access-mask set           |
 | `smb_share_activity`      | Number of remote machines using each share       |
 | `smb_share_byremote`      | Number of shares used by each remote machine     |
 

--- a/internal/metrics/smbinfo.go
+++ b/internal/metrics/smbinfo.go
@@ -2,17 +2,19 @@
 
 package metrics
 
-import "strings"
-
 // SMBInfo provides a bridge layer between raw smbstatus info and exported
 // metric counters. It also implements the more complex logic which requires in
 // memory re-mapping of the low-level information (e.g., stats by machine/user).
 type SMBInfo struct {
-	smbstat *SMBStatus
+	tconsStatus    *SMBStatus
+	sessionsStatus *SMBStatus
 }
 
 func NewSMBInfo() *SMBInfo {
-	return &SMBInfo{smbstat: NewSMBStatus()}
+	return &SMBInfo{
+		tconsStatus:    NewSMBStatus(),
+		sessionsStatus: NewSMBStatus(),
+	}
 }
 
 func NewUpdatedSMBInfo() (*SMBInfo, error) {
@@ -22,21 +24,26 @@ func NewUpdatedSMBInfo() (*SMBInfo, error) {
 }
 
 func (smbinfo *SMBInfo) Update() error {
-	smbstat, err := RunSMBStatus()
+	tconsStatus, err := RunSMBStatusShares()
 	if err != nil {
 		return err
 	}
-	smbinfo.smbstat = smbstat
+	sessionsStatus, err := RunSMBStatusProcesses()
+	if err != nil {
+		return err
+	}
+	smbinfo.tconsStatus = tconsStatus
+	smbinfo.sessionsStatus = sessionsStatus
 	return nil
 }
 
 func (smbinfo *SMBInfo) TotalSessions() int {
-	return len(smbinfo.smbstat.Sessions)
+	return len(smbinfo.sessionsStatus.Sessions)
 }
 
 func (smbinfo *SMBInfo) TotalTreeCons() int {
 	total := 0
-	for _, tcon := range smbinfo.smbstat.TCons {
+	for _, tcon := range smbinfo.tconsStatus.TCons {
 		serviceID := tcon.Service
 		if isInternalServiceID(serviceID) {
 			continue
@@ -46,25 +53,9 @@ func (smbinfo *SMBInfo) TotalTreeCons() int {
 	return total
 }
 
-func (smbinfo *SMBInfo) TotalOpenFiles() int {
-	return len(smbinfo.smbstat.OpenFiles)
-}
-
-func (smbinfo *SMBInfo) TotalOpenFilesAccessRW() int {
-	total := 0
-	for _, openf := range smbinfo.smbstat.OpenFiles {
-		for _, opens := range openf.Opens {
-			if strings.Contains(opens.AccessMask.Text, "RW") {
-				total++
-			}
-		}
-	}
-	return total
-}
-
 func (smbinfo *SMBInfo) TotalConnectedUsers() int {
 	users := map[string]bool{}
-	for _, session := range smbinfo.smbstat.Sessions {
+	for _, session := range smbinfo.sessionsStatus.Sessions {
 		username := session.Username
 		if len(username) > 0 {
 			users[username] = true
@@ -75,7 +66,7 @@ func (smbinfo *SMBInfo) TotalConnectedUsers() int {
 
 func (smbinfo *SMBInfo) MapMachineToSessions() map[string][]*SMBStatusSession {
 	ret := map[string][]*SMBStatusSession{}
-	for _, session := range smbinfo.smbstat.Sessions {
+	for _, session := range smbinfo.sessionsStatus.Sessions {
 		machineID := session.RemoteMachine
 		sessionRef := &session
 		ret[machineID] = append(ret[machineID], sessionRef)
@@ -85,7 +76,7 @@ func (smbinfo *SMBInfo) MapMachineToSessions() map[string][]*SMBStatusSession {
 
 func (smbinfo *SMBInfo) MapServiceToTreeCons() map[string][]*SMBStatusTreeCon {
 	ret := map[string][]*SMBStatusTreeCon{}
-	for _, tcon := range smbinfo.smbstat.TCons {
+	for _, tcon := range smbinfo.tconsStatus.TCons {
 		serviceID := tcon.Service
 		if isInternalServiceID(serviceID) {
 			continue
@@ -98,7 +89,7 @@ func (smbinfo *SMBInfo) MapServiceToTreeCons() map[string][]*SMBStatusTreeCon {
 
 func (smbinfo *SMBInfo) MapMachineToTreeCons() map[string][]*SMBStatusTreeCon {
 	ret := map[string][]*SMBStatusTreeCon{}
-	for _, tcon := range smbinfo.smbstat.TCons {
+	for _, tcon := range smbinfo.tconsStatus.TCons {
 		serviceID := tcon.Service
 		if isInternalServiceID(serviceID) {
 			continue
@@ -112,7 +103,7 @@ func (smbinfo *SMBInfo) MapMachineToTreeCons() map[string][]*SMBStatusTreeCon {
 
 func (smbinfo *SMBInfo) MapServiceToMachines() map[string]map[string]int {
 	ret := map[string]map[string]int{}
-	for _, tcon := range smbinfo.smbstat.TCons {
+	for _, tcon := range smbinfo.tconsStatus.TCons {
 		serviceID := tcon.Service
 		if isInternalServiceID(serviceID) {
 			continue
@@ -130,7 +121,7 @@ func (smbinfo *SMBInfo) MapServiceToMachines() map[string]map[string]int {
 
 func (smbinfo *SMBInfo) MapMachineToServies() map[string]map[string]int {
 	ret := map[string]map[string]int{}
-	for _, tcon := range smbinfo.smbstat.TCons {
+	for _, tcon := range smbinfo.tconsStatus.TCons {
 		serviceID := tcon.Service
 		if isInternalServiceID(serviceID) {
 			continue

--- a/internal/metrics/smbstatus_test.go
+++ b/internal/metrics/smbstatus_test.go
@@ -948,18 +948,16 @@ func TestParseSMBStatusTCons(t *testing.T) {
 	assert.Equal(t, len(dat.TCons), 2)
 
 	dat, err = parseSMBStatus(smbstatusOutput2)
-	assert.NoError(t, err)
 	assert.Equal(t, len(dat.TCons), 1)
-
-	shares, err := parseSMBStatusTreeCons(smbstatusOutput2)
 	assert.NoError(t, err)
-	assert.Equal(t, len(shares), 1)
-	share1 := shares[0]
-	assert.Equal(t, share1.Service, "share1")
-	assert.Equal(t, share1.ServerID.PID, "355")
-	assert.Equal(t, share1.Machine, "::1")
+	tcons := dat.ListTreeCons()
+	assert.Equal(t, len(tcons), 1)
+	tcon1 := tcons[0]
+	assert.Equal(t, tcon1.Service, "share1")
+	assert.Equal(t, tcon1.ServerID.PID, "355")
+	assert.Equal(t, tcon1.Machine, "::1")
 
-	sharesMap := makeSmbSharesMap(shares)
+	sharesMap := makeSmbSharesMap(tcons)
 	assert.Equal(t, len(sharesMap), 1)
 	for machine, share := range sharesMap {
 		sharesCount := len(share)
@@ -973,9 +971,8 @@ func TestParseSMBStatusAll(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(dat.Sessions), 1)
 	assert.Equal(t, len(dat.TCons), 1)
-	assert.Equal(t, len(dat.OpenFiles), 1)
 
-	dat2, err := parseSMBStatus(smbstatusOutput4)
+	dat2, err := parseSMBStatusLocks(smbstatusOutput4)
 	assert.NoError(t, err)
 	assert.Equal(t, len(dat2.OpenFiles), 2)
 }
@@ -993,7 +990,7 @@ func TestParseSMBStatusLocks(t *testing.T) {
 }
 
 func TestParseSMBStatusOpenFiles(t *testing.T) {
-	status, err := parseSMBStatus(smbstatusOutput6)
+	status, err := parseSMBStatusLocks(smbstatusOutput6)
 	assert.NoError(t, err)
 	assert.Equal(t, len(status.OpenFiles), 2)
 	openFileAa := status.OpenFiles["/A/a"]


### PR DESCRIPTION
 Doing a full 'smbstatus --json' may be a costly operation on heavily loaded cluster. In particular, retrieving the 'open_files' section may cause 'smbstatus' to hold ctdb lock for long period of time, which in turn may cause performance degradation to real users.
    
Improve performance by:
1. Do two distinct calls to 'smbstatus': one for 'tcons' section and one for 'sessions' section.
2. Avoid redundant calls to 'smbstatus' by havin only two collectors.
3. Removed metrics which require 'open_files' section.
