### PR TITLE
metrics: export using explicit values

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,20 @@ $ curl --request GET "http://localhost:9922/metrics"
 | `smb_share_byremote`      | Number of shares used by each remote machine     |
 
 
-## Profile metrics
+## Profile metrics (per operation)
 
-| Metric name               | Description                                      |
-|---------------------------|--------------------------------------------------|
-| `smb_smb2_request_total`  | Number of SMB2 requests                          |
-| `smb_vfs_call_total`      | Number of calls to VFS layer                     |
-| `smb_vfs_io_call_total`   | Number of I/O calls to VFS layer                 |
+| Metric name                                  | Description                                              |
+|----------------------------------------------|----------------------------------------------------------|
+| `smb_smb2_request_total`                     | Total number of SMB2 requests                            |
+| `smb_smb2_request_inbytes`                   | Bytes received for SMB2 requests                         |
+| `smb_smb2_request_outbytes`                  | Bytes replied for SMB2 requests                          |
+| `smb_smb2_request_duration_microseconds_sum` | Execution time in microseconds of SMB2 requests          |
+| `smb_vfs_total`                              | Total number of calls to underlying VFS layer            |
+| `smb_vfs_io_total`                           | Total number of I/O calls to underlying VFS layer        |
+| `smb_vfs_io_bytes`                           | Number of bytes transferred via underlying VFS I/O layer |
+| `smb_vfs_io_duration_microseconds_sum`       | Execution time in microseconds of VFS I/O requests       |
 
-smb_vfs_call_total
+
 ## Example
 
 The following example is from a setup with 2 shares and 2 users connected and
@@ -91,63 +96,173 @@ When running with profile enabled, we get also the following metrics:
 ```console
 # HELP smb_smb2_request_total Total number of SMB2 requests
 # TYPE smb_smb2_request_total gauge
-smb_smb2_request_total{idle="0",inbytes="0",operation="break",outbytes="0",time="0"} 0
-smb_smb2_request_total{idle="0",inbytes="0",operation="cancel",outbytes="0",time="0"} 0
-smb_smb2_request_total{idle="0",inbytes="0",operation="lock",outbytes="0",time="0"} 0
-smb_smb2_request_total{idle="0",inbytes="0",operation="logoff",outbytes="0",time="0"} 0
-smb_smb2_request_total{idle="0",inbytes="0",operation="notify",outbytes="0",time="0"} 0
-smb_smb2_request_total{idle="0",inbytes="0",operation="tdis",outbytes="0",time="0"} 0
-smb_smb2_request_total{idle="0",inbytes="1156",operation="keepalive",outbytes="1156",time="98"} 17
-smb_smb2_request_total{idle="0",inbytes="12995",operation="read",outbytes="232793072",time="102307"} 115
-smb_smb2_request_total{idle="0",inbytes="16852",operation="getinfo",outbytes="27754",time="26869"} 162
-smb_smb2_request_total{idle="0",inbytes="23069904",operation="write",outbytes="880",time="30958"} 11
-smb_smb2_request_total{idle="0",inbytes="240",operation="negprot",outbytes="268",time="4049881"} 1
-smb_smb2_request_total{idle="0",inbytes="240",operation="tcon",outbytes="160",time="97672"} 2
-smb_smb2_request_total{idle="0",inbytes="26312",operation="close",outbytes="37712",time="101378"} 299
-smb_smb2_request_total{idle="0",inbytes="295",operation="ioctl",outbytes="337",time="186"} 2
-smb_smb2_request_total{idle="0",inbytes="3136",operation="setinfo",outbytes="1740",time="56382"} 26
-smb_smb2_request_total{idle="0",inbytes="430",operation="sesssetup",outbytes="264",time="15242"} 2
-smb_smb2_request_total{idle="0",inbytes="74352",operation="create",outbytes="82692",time="705058"} 363
-smb_smb2_request_total{idle="0",inbytes="968",operation="flush",outbytes="748",time="1609"} 11
-smb_smb2_request_total{idle="0",inbytes="980",operation="find",outbytes="3629",time="19929"} 10
-# HELP smb_vfs_call_total Total number of calls to underlying VFS layer
-# TYPE smb_vfs_call_total gauge
-smb_vfs_call_total{operation="chdir",time="9045"} 209
-smb_vfs_call_total{operation="chmod",time="0"} 0
-smb_vfs_call_total{operation="close",time="12056"} 873
-smb_vfs_call_total{operation="closedir",time="3738"} 83
-smb_vfs_call_total{operation="createfile",time="0"} 0
-smb_vfs_call_total{operation="fallocate",time="0"} 0
-smb_vfs_call_total{operation="fchmod",time="603"} 11
-smb_vfs_call_total{operation="fchown",time="0"} 0
-smb_vfs_call_total{operation="fdopendir",time="1839"} 83
-smb_vfs_call_total{operation="fntimes",time="14315"} 22
-smb_vfs_call_total{operation="fstat",time="42921"} 1790
-smb_vfs_call_total{operation="fstatat",time="0"} 0
-smb_vfs_call_total{operation="ftruncate",time="0"} 0
-smb_vfs_call_total{operation="getwd",time="7"} 2
-smb_vfs_call_total{operation="lchown",time="0"} 0
-smb_vfs_call_total{operation="linkat",time="0"} 0
-smb_vfs_call_total{operation="lseek",time="0"} 0
-smb_vfs_call_total{operation="lstat",time="9"} 1
-smb_vfs_call_total{operation="mkdirat",time="2614"} 2
-smb_vfs_call_total{operation="mknodat",time="0"} 0
-smb_vfs_call_total{operation="open",time="0"} 0
-smb_vfs_call_total{operation="openat",time="138723"} 1034
-smb_vfs_call_total{operation="opendir",time="0"} 0
-smb_vfs_call_total{operation="readdir",time="305110"} 534
-smb_vfs_call_total{operation="readlinkat",time="0"} 0
-smb_vfs_call_total{operation="realpath",time="17"} 4
-smb_vfs_call_total{operation="renameat",time="22538"} 5
-smb_vfs_call_total{operation="rewinddir",time="0"} 0
-smb_vfs_call_total{operation="stat",time="42770"} 479
-smb_vfs_call_total{operation="symlinkat",time="0"} 0
-smb_vfs_call_total{operation="unlinkat",time="7843"} 10
-# HELP smb_vfs_io_call_total Total number of I/O calls to underlying VFS layer
-# TYPE smb_vfs_io_call_total gauge
-smb_vfs_io_call_total{bytes="0",idle="0",operation="pread",time="0"} 0
-smb_vfs_io_call_total{bytes="0",idle="0",operation="pwrite",time="0"} 0
-smb_vfs_io_call_total{bytes="0",idle="14",operation="asys_fsync",time="1416"} 11
-smb_vfs_io_call_total{bytes="23068672",idle="23",operation="asys_pwrite",time="29534"} 11
-smb_vfs_io_call_total{bytes="232783872",idle="267",operation="asys_pread",time="99338"} 115
+smb_smb2_request_total{operation="break"} 0
+smb_smb2_request_total{operation="cancel"} 0
+smb_smb2_request_total{operation="close"} 1347
+smb_smb2_request_total{operation="create"} 3378
+smb_smb2_request_total{operation="find"} 394
+smb_smb2_request_total{operation="flush"} 15
+smb_smb2_request_total{operation="getinfo"} 653
+smb_smb2_request_total{operation="ioctl"} 103
+smb_smb2_request_total{operation="keepalive"} 1
+smb_smb2_request_total{operation="lock"} 0
+smb_smb2_request_total{operation="logoff"} 0
+smb_smb2_request_total{operation="negprot"} 1
+smb_smb2_request_total{operation="notify"} 0
+smb_smb2_request_total{operation="read"} 228
+smb_smb2_request_total{operation="sesssetup"} 2
+smb_smb2_request_total{operation="setinfo"} 109
+smb_smb2_request_total{operation="tcon"} 2
+smb_smb2_request_total{operation="tdis"} 0
+smb_smb2_request_total{operation="write"} 145
+# HELP smb_smb2_request_inbytes Bytes received for SMB2 requests
+# TYPE smb_smb2_request_inbytes gauge
+smb_smb2_request_inbytes{operation="break"} 0
+smb_smb2_request_inbytes{operation="cancel"} 0
+smb_smb2_request_inbytes{operation="close"} 118536
+smb_smb2_request_inbytes{operation="create"} 716288
+smb_smb2_request_inbytes{operation="find"} 38612
+smb_smb2_request_inbytes{operation="flush"} 1320
+smb_smb2_request_inbytes{operation="getinfo"} 67916
+smb_smb2_request_inbytes{operation="ioctl"} 15313
+smb_smb2_request_inbytes{operation="keepalive"} 68
+smb_smb2_request_inbytes{operation="lock"} 0
+smb_smb2_request_inbytes{operation="logoff"} 0
+smb_smb2_request_inbytes{operation="negprot"} 240
+smb_smb2_request_inbytes{operation="notify"} 0
+smb_smb2_request_inbytes{operation="read"} 25764
+smb_smb2_request_inbytes{operation="sesssetup"} 430
+smb_smb2_request_inbytes{operation="setinfo"} 15528
+smb_smb2_request_inbytes{operation="tcon"} 240
+smb_smb2_request_inbytes{operation="tdis"} 0
+smb_smb2_request_inbytes{operation="write"} 8.272958e+06
+# HELP smb_smb2_request_outbytes Bytes replied for SMB2 requests
+# TYPE smb_smb2_request_outbytes gauge
+smb_smb2_request_outbytes{operation="break"} 0
+smb_smb2_request_outbytes{operation="cancel"} 0
+smb_smb2_request_outbytes{operation="close"} 170072
+smb_smb2_request_outbytes{operation="create"} 490469
+smb_smb2_request_outbytes{operation="find"} 91957
+smb_smb2_request_outbytes{operation="flush"} 1020
+smb_smb2_request_outbytes{operation="getinfo"} 142258
+smb_smb2_request_outbytes{operation="ioctl"} 13849
+smb_smb2_request_outbytes{operation="keepalive"} 68
+smb_smb2_request_outbytes{operation="lock"} 0
+smb_smb2_request_outbytes{operation="logoff"} 0
+smb_smb2_request_outbytes{operation="negprot"} 268
+smb_smb2_request_outbytes{operation="notify"} 0
+smb_smb2_request_outbytes{operation="read"} 1.6145173e+07
+smb_smb2_request_outbytes{operation="sesssetup"} 264
+smb_smb2_request_outbytes{operation="setinfo"} 7668
+smb_smb2_request_outbytes{operation="tcon"} 160
+smb_smb2_request_outbytes{operation="tdis"} 0
+smb_smb2_request_outbytes{operation="write"} 11600
+# HELP smb_smb2_request_duration_microseconds_sum Execution time in microseconds of SMB2 requests
+# TYPE smb_smb2_request_duration_microseconds_sum gauge
+smb_smb2_request_duration_microseconds_sum{operation="break"} 0
+smb_smb2_request_duration_microseconds_sum{operation="cancel"} 0
+smb_smb2_request_duration_microseconds_sum{operation="close"} 431570
+smb_smb2_request_duration_microseconds_sum{operation="create"} 7.244576e+06
+smb_smb2_request_duration_microseconds_sum{operation="find"} 310193
+smb_smb2_request_duration_microseconds_sum{operation="flush"} 149128
+smb_smb2_request_duration_microseconds_sum{operation="getinfo"} 59480
+smb_smb2_request_duration_microseconds_sum{operation="ioctl"} 14357
+smb_smb2_request_duration_microseconds_sum{operation="keepalive"} 4
+smb_smb2_request_duration_microseconds_sum{operation="lock"} 0
+smb_smb2_request_duration_microseconds_sum{operation="logoff"} 0
+smb_smb2_request_duration_microseconds_sum{operation="negprot"} 3.737457e+06
+smb_smb2_request_duration_microseconds_sum{operation="notify"} 0
+smb_smb2_request_duration_microseconds_sum{operation="read"} 30674
+smb_smb2_request_duration_microseconds_sum{operation="sesssetup"} 16994
+smb_smb2_request_duration_microseconds_sum{operation="setinfo"} 327027
+smb_smb2_request_duration_microseconds_sum{operation="tcon"} 192715
+smb_smb2_request_duration_microseconds_sum{operation="tdis"} 0
+smb_smb2_request_duration_microseconds_sum{operation="write"} 73739
+# HELP smb_vfs_io_bytes Number of bytes transferred via underlying VFS I/O layer
+# TYPE smb_vfs_io_bytes gauge
+smb_vfs_io_bytes{operation="asys_fsync"} 0
+smb_vfs_io_bytes{operation="asys_pread"} 1.6126933e+07
+smb_vfs_io_bytes{operation="asys_pwrite"} 8.256718e+06
+smb_vfs_io_bytes{operation="pread"} 0
+smb_vfs_io_bytes{operation="pwrite"} 0
+# HELP smb_vfs_io_duration_microseconds_sum Execution time in microseconds of VFS I/O requests
+# TYPE smb_vfs_io_duration_microseconds_sum gauge
+smb_vfs_io_duration_microseconds_sum{operation="asys_fsync"} 148760
+smb_vfs_io_duration_microseconds_sum{operation="asys_pread"} 26798
+smb_vfs_io_duration_microseconds_sum{operation="asys_pwrite"} 68615
+smb_vfs_io_duration_microseconds_sum{operation="pread"} 0
+smb_vfs_io_duration_microseconds_sum{operation="pwrite"} 0
+# HELP smb_vfs_io_total Total number of I/O calls to underlying VFS layer
+# TYPE smb_vfs_io_total gauge
+smb_vfs_io_total{operation="asys_fsync"} 15
+smb_vfs_io_total{operation="asys_pread"} 228
+smb_vfs_io_total{operation="asys_pwrite"} 145
+smb_vfs_io_total{operation="pread"} 0
+smb_vfs_io_total{operation="pwrite"} 0
+# HELP smb_vfs_total Total number of calls to underlying VFS layer
+# TYPE smb_vfs_total gauge
+smb_vfs_total{operation="chdir"} 810
+smb_vfs_total{operation="chmod"} 0
+smb_vfs_total{operation="close"} 23138
+smb_vfs_total{operation="closedir"} 2403
+smb_vfs_total{operation="createfile"} 0
+smb_vfs_total{operation="fallocate"} 0
+smb_vfs_total{operation="fchmod"} 79
+smb_vfs_total{operation="fchown"} 0
+smb_vfs_total{operation="fdopendir"} 2403
+smb_vfs_total{operation="fntimes"} 107
+smb_vfs_total{operation="fstat"} 18204
+smb_vfs_total{operation="fstatat"} 0
+smb_vfs_total{operation="ftruncate"} 12
+smb_vfs_total{operation="getwd"} 2
+smb_vfs_total{operation="lchown"} 0
+smb_vfs_total{operation="linkat"} 16
+smb_vfs_total{operation="lseek"} 0
+smb_vfs_total{operation="lstat"} 29
+smb_vfs_total{operation="mkdirat"} 58
+smb_vfs_total{operation="mknodat"} 0
+smb_vfs_total{operation="open"} 0
+smb_vfs_total{operation="openat"} 27689
+smb_vfs_total{operation="opendir"} 0
+smb_vfs_total{operation="readdir"} 24129
+smb_vfs_total{operation="readlinkat"} 0
+smb_vfs_total{operation="realpath"} 4
+smb_vfs_total{operation="renameat"} 76
+smb_vfs_total{operation="rewinddir"} 0
+smb_vfs_total{operation="stat"} 2049
+smb_vfs_total{operation="symlinkat"} 0
+smb_vfs_total{operation="unlinkat"} 110
+# HELP smb_vfs_duration_microseconds_sum Execution time in microseconds of VFS requests
+# TYPE smb_vfs_duration_microseconds_sum gauge
+smb_vfs_duration_microseconds_sum{operation="chdir"} 12524
+smb_vfs_duration_microseconds_sum{operation="chmod"} 0
+smb_vfs_duration_microseconds_sum{operation="close"} 55989
+smb_vfs_duration_microseconds_sum{operation="closedir"} 63982
+smb_vfs_duration_microseconds_sum{operation="createfile"} 0
+smb_vfs_duration_microseconds_sum{operation="fallocate"} 0
+smb_vfs_duration_microseconds_sum{operation="fchmod"} 2447
+smb_vfs_duration_microseconds_sum{operation="fchown"} 0
+smb_vfs_duration_microseconds_sum{operation="fdopendir"} 39712
+smb_vfs_duration_microseconds_sum{operation="fntimes"} 16961
+smb_vfs_duration_microseconds_sum{operation="fstat"} 157620
+smb_vfs_duration_microseconds_sum{operation="fstatat"} 0
+smb_vfs_duration_microseconds_sum{operation="ftruncate"} 180999
+smb_vfs_duration_microseconds_sum{operation="getwd"} 6
+smb_vfs_duration_microseconds_sum{operation="lchown"} 0
+smb_vfs_duration_microseconds_sum{operation="linkat"} 11593
+smb_vfs_duration_microseconds_sum{operation="lseek"} 0
+smb_vfs_duration_microseconds_sum{operation="lstat"} 828
+smb_vfs_duration_microseconds_sum{operation="mkdirat"} 40445
+smb_vfs_duration_microseconds_sum{operation="mknodat"} 0
+smb_vfs_duration_microseconds_sum{operation="open"} 0
+smb_vfs_duration_microseconds_sum{operation="openat"} 790532
+smb_vfs_duration_microseconds_sum{operation="opendir"} 0
+smb_vfs_duration_microseconds_sum{operation="readdir"} 5.27503e+06
+smb_vfs_duration_microseconds_sum{operation="readlinkat"} 0
+smb_vfs_duration_microseconds_sum{operation="realpath"} 20
+smb_vfs_duration_microseconds_sum{operation="renameat"} 253650
+smb_vfs_duration_microseconds_sum{operation="rewinddir"} 0
+smb_vfs_duration_microseconds_sum{operation="stat"} 131346
+smb_vfs_duration_microseconds_sum{operation="symlinkat"} 0
+smb_vfs_duration_microseconds_sum{operation="unlinkat"} 106974
 ```


### PR DESCRIPTION
Labels can not be used in order to plot graphs based on metrics. Export various smb profile stats as explicit metric values, where only the operation name is used as label.

Use helper mapping from operation name to entry when emitting output metrics in order to avoid boilerplate code.