### PR TITLE
metrics: export 'netbios name' as label

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ curl --request GET "http://localhost:9922/metrics"
 
 # HELP smb_metrics_status Current metrics-collector status versions
 # TYPE smb_metrics_status gauge
-smb_metrics_status{commitid="092fe2bb0",ctdbvers="4.20.0-103",sambaimage="",sambavers="4.20.0-103",version="v0.2-28-g092fe2b"} 1
+smb_metrics_status{commitid="092fe2bb0",ctdbvers="4.20.0-103",netbiosname="cluster1",sambaimage="",sambavers="4.20.0-103",version="v0.2-28-g092fe2b"} 1
 # HELP smb_sessions_total Number of currently active SMB sessions
 # TYPE smb_sessions_total gauge
 smb_sessions_total 8

--- a/internal/metrics/collectors.go
+++ b/internal/metrics/collectors.go
@@ -48,6 +48,10 @@ func (col *smbVersionsCollector) Collect(ch chan<- prometheus.Metric) {
 	if err != nil {
 		status = 1
 	}
+	netbiosName, err := resolveNetbiosName()
+	if err != nil {
+		netbiosName = ""
+	}
 	ch <- prometheus.MustNewConstMetric(
 		col.dsc[0],
 		prometheus.GaugeValue,
@@ -57,6 +61,7 @@ func (col *smbVersionsCollector) Collect(ch chan<- prometheus.Metric) {
 		vers.SambaImage,
 		vers.SambaVersion,
 		vers.CtdbVersion,
+		netbiosName,
 	)
 }
 
@@ -74,6 +79,7 @@ func (sme *smbMetricsExporter) newSMBVersionsCollector() prometheus.Collector {
 				"sambaimage",
 				"sambavers",
 				"ctdbvers",
+				"netbiosname",
 			}, nil),
 	}
 	return col

--- a/internal/metrics/versions.go
+++ b/internal/metrics/versions.go
@@ -64,3 +64,7 @@ func resolveCtdbVersion() (string, error) {
 func executeRpmQCommand(name string) (string, error) {
 	return executeCommand("rpm", "-q", name)
 }
+
+func resolveNetbiosName() (string, error) {
+	return executeCommand("net", "conf", "getparm", "global", "netbios name")
+}


### PR DESCRIPTION
Add "netbiosname" label to smb_metrics_status which may be used as cluster identifier on deployments which run multiple instances of smbmetrics via single dashboard.