### PR TITLE
Support per-share metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,3 +266,41 @@ smb_vfs_duration_microseconds_sum{operation="stat"} 131346
 smb_vfs_duration_microseconds_sum{operation="symlinkat"} 0
 smb_vfs_duration_microseconds_sum{operation="unlinkat"} 106974
 ```
+
+When running with profile-per-share enabled ("smbd profiling share = on")
+we get additional per-share metrics:
+
+```console
+smb_smb2_request_duration_microseconds_sum{client="192.168.122.25",netbiosname="smb-cephfs",operation="close",share="smbshare"} 7351
+smb_smb2_request_duration_microseconds_sum{client="192.168.122.25",netbiosname="smb-cephfs",operation="create",share="smbshare"} 59801
+smb_smb2_request_duration_microseconds_sum{client="192.168.122.25",netbiosname="smb-cephfs",operation="find",share="smbshare"} 5972
+smb_smb2_request_duration_microseconds_sum{client="192.168.122.25",netbiosname="smb-cephfs",operation="flush",share="smbshare"} 10257
+...
+smb_smb2_request_inbytes{client="192.168.122.25",netbiosname="smb-cephfs",operation="close",share="smbshare"} 1584
+smb_smb2_request_inbytes{client="192.168.122.25",netbiosname="smb-cephfs",operation="create",share="smbshare"} 3336
+smb_smb2_request_inbytes{client="192.168.122.25",netbiosname="smb-cephfs",operation="find",share="smbshare"} 392
+smb_smb2_request_inbytes{client="192.168.122.25",netbiosname="smb-cephfs",operation="flush",share="smbshare"} 88
+...
+smb_smb2_request_total{client="192.168.122.25",netbiosname="smb-cephfs",operation="close",share="smbshare"} 18
+smb_smb2_request_total{client="192.168.122.25",netbiosname="smb-cephfs",operation="create",share="smbshare"} 18
+smb_smb2_request_total{client="192.168.122.25",netbiosname="smb-cephfs",operation="find",share="smbshare"} 4
+smb_smb2_request_total{client="192.168.122.25",netbiosname="smb-cephfs",operation="flush",share="smbshare"} 1
+...
+smb_vfs_duration_microseconds_sum{client="192.168.122.25",netbiosname="smb-cephfs",operation="chdir",share="smbshare"} 562
+smb_vfs_duration_microseconds_sum{client="192.168.122.25",netbiosname="smb-cephfs",operation="chmod",share="smbshare"} 0
+smb_vfs_duration_microseconds_sum{client="192.168.122.25",netbiosname="smb-cephfs",operation="close",share="smbshare"} 4279
+smb_vfs_duration_microseconds_sum{client="192.168.122.25",netbiosname="smb-cephfs",operation="closedir",share="smbshare"} 46
+...
+smb_vfs_io_bytes{client="192.168.122.25",netbiosname="smb-cephfs",operation="asys_fsync",share="smbshare"} 0
+smb_vfs_io_bytes{client="192.168.122.25",netbiosname="smb-cephfs",operation="asys_pread",share="smbshare"} 303
+smb_vfs_io_bytes{client="192.168.122.25",netbiosname="smb-cephfs",operation="asys_pwrite",share="smbshare"} 17
+smb_vfs_io_bytes{client="192.168.122.25",netbiosname="smb-cephfs",operation="pread",share="smbshare"} 0
+smb_vfs_io_bytes{client="192.168.122.25",netbiosname="smb-cephfs",operation="pwrite",share="smbshare"} 0
+...
+smb_vfs_io_total{client="192.168.122.25",netbiosname="smb-cephfs",operation="asys_fsync",share="smbshare"} 1
+smb_vfs_io_total{client="192.168.122.25",netbiosname="smb-cephfs",operation="asys_pread",share="smbshare"} 2
+smb_vfs_io_total{client="192.168.122.25",netbiosname="smb-cephfs",operation="asys_pwrite",share="smbshare"} 1
+smb_vfs_io_total{client="192.168.122.25",netbiosname="smb-cephfs",operation="pread",share="smbshare"} 0
+smb_vfs_io_total{client="192.168.122.25",netbiosname="smb-cephfs",operation="pwrite",share="smbshare"} 0
+...
+```

--- a/internal/metrics/collectors.go
+++ b/internal/metrics/collectors.go
@@ -27,8 +27,20 @@ func (sme *smbMetricsExporter) register() error {
 
 type smbCollector struct {
 	// nolint:structcheck
-	sme *smbMetricsExporter
-	dsc []*prometheus.Desc
+	sme         *smbMetricsExporter
+	dsc         []*prometheus.Desc
+	netbiosName string
+}
+
+func (col *smbCollector) Refresh() {
+	if col.netbiosName != "" {
+		return
+	}
+	netbiosName, err := resolveNetbiosName()
+	if err != nil {
+		return
+	}
+	col.netbiosName = netbiosName
 }
 
 func (col *smbCollector) Describe(ch chan<- *prometheus.Desc) {
@@ -44,13 +56,10 @@ type smbVersionsCollector struct {
 
 func (col *smbVersionsCollector) Collect(ch chan<- prometheus.Metric) {
 	status := 0
+	col.Refresh()
 	vers, err := ResolveVersions(col.clnt)
 	if err != nil {
 		status = 1
-	}
-	netbiosName, err := resolveNetbiosName()
-	if err != nil {
-		netbiosName = ""
 	}
 	ch <- prometheus.MustNewConstMetric(
 		col.dsc[0],
@@ -61,7 +70,7 @@ func (col *smbVersionsCollector) Collect(ch chan<- prometheus.Metric) {
 		vers.SambaImage,
 		vers.SambaVersion,
 		vers.CtdbVersion,
-		netbiosName,
+		col.netbiosName,
 	)
 }
 
@@ -94,6 +103,7 @@ func (col *smbStatusCollector) Collect(ch chan<- prometheus.Metric) {
 	if err != nil {
 		return
 	}
+	col.Refresh()
 	ch <- prometheus.MustNewConstMetric(col.dsc[0],
 		prometheus.GaugeValue, float64(smbInfo.TotalSessions()))
 
@@ -163,18 +173,34 @@ func (col *smbProfileCollector) Collect(ch chan<- prometheus.Metric) {
 	if err != nil {
 		return
 	}
+	col.Refresh()
 	smb2Calls := smbProfileInfo.profileStatus.SMB2Calls
 	if smb2Calls != nil {
-		col.collectSMB2CallsMetrics(ch, smb2Calls)
+		col.collectSMB2CallsMetrics(ch, smb2Calls, "", "")
 	}
 	sysCalls := smbProfileInfo.profileStatus.SystemCalls
 	if sysCalls != nil {
-		col.collectSysCallsMetrics(ch, sysCalls)
+		col.collectSysCallsMetrics(ch, sysCalls, "", "")
+	}
+	for key, extended := range smbProfileInfo.profileStatus.Extended {
+		sharename, client := ParseExtendedProfileKey(key)
+		if sharename == "" || client == "" {
+			continue
+		}
+		smb2Calls = extended.SMB2Calls
+		if smb2Calls != nil {
+			col.collectSMB2CallsMetrics(ch, smb2Calls, sharename, client)
+		}
+		sysCalls = extended.SystemCalls
+		if sysCalls != nil {
+			col.collectSysCallsMetrics(ch, sysCalls, sharename, client)
+		}
 	}
 }
 
 func (col *smbProfileCollector) collectSMB2CallsMetrics(
-	ch chan<- prometheus.Metric, smb2Calls *SMBProfileSMB2Calls) {
+	ch chan<- prometheus.Metric, smb2Calls *SMBProfileSMB2Calls,
+	sharename, client string) {
 	operationToProfileCallEntry := map[string]*SMBProfileCallEntry{
 		"negprot":   &smb2Calls.NegProt,
 		"sesssetup": &smb2Calls.SessSetup,
@@ -197,15 +223,16 @@ func (col *smbProfileCollector) collectSMB2CallsMetrics(
 		"break":     &smb2Calls.Break,
 	}
 	for op, pce := range operationToProfileCallEntry {
-		ch <- col.smb2RequestTotalMetric(op, pce)
-		ch <- col.smb2RequestInbytesMetric(op, pce)
-		ch <- col.smb2RequestOutbytesMetric(op, pce)
-		ch <- col.smb2RequestDurationMetric(op, pce)
+		ch <- col.smb2RequestTotalMetric(sharename, client, op, pce)
+		ch <- col.smb2RequestInbytesMetric(sharename, client, op, pce)
+		ch <- col.smb2RequestOutbytesMetric(sharename, client, op, pce)
+		ch <- col.smb2RequestDurationMetric(sharename, client, op, pce)
 	}
 }
 
 func (col *smbProfileCollector) collectSysCallsMetrics(
-	ch chan<- prometheus.Metric, sysCalls *SMBProfileSyscalls) {
+	ch chan<- prometheus.Metric, sysCalls *SMBProfileSyscalls,
+	sharename, client string) {
 	operationToProfileIOEntry := map[string]*SMBProfileIOEntry{
 		"pread":       &sysCalls.PRead,
 		"asys_pread":  &sysCalls.AsysPRead,
@@ -247,137 +274,165 @@ func (col *smbProfileCollector) collectSysCallsMetrics(
 		"realpath":   &sysCalls.RealPath,
 	}
 	for op, pioe := range operationToProfileIOEntry {
-		ch <- col.vfsIOTotalMetric(op, pioe)
-		ch <- col.vfsIOBytesMetric(op, pioe)
-		ch <- col.vfsIODurationMetric(op, pioe)
+		ch <- col.vfsIOTotalMetric(sharename, client, op, pioe)
+		ch <- col.vfsIOBytesMetric(sharename, client, op, pioe)
+		ch <- col.vfsIODurationMetric(sharename, client, op, pioe)
 	}
 	for op, pe := range operationToProfileEntry {
-		ch <- col.vfsTotalMetric(op, pe)
-		ch <- col.vfsDurationMetric(op, pe)
+		ch <- col.vfsTotalMetric(sharename, client, op, pe)
+		ch <- col.vfsDurationMetric(sharename, client, op, pe)
 	}
 }
 
-func (col *smbProfileCollector) smb2RequestTotalMetric(operation string,
-	pce *SMBProfileCallEntry) prometheus.Metric {
+func (col *smbProfileCollector) smb2RequestTotalMetric(
+	sharename, client, operation string, pce *SMBProfileCallEntry) prometheus.Metric {
 	return prometheus.MustNewConstMetric(
 		col.dsc[0],
 		prometheus.GaugeValue,
 		float64(pce.Count),
+		col.netbiosName,
+		sharename,
+		client,
 		operation)
 }
 
-func (col *smbProfileCollector) smb2RequestInbytesMetric(operation string,
-	pce *SMBProfileCallEntry) prometheus.Metric {
+func (col *smbProfileCollector) smb2RequestInbytesMetric(
+	sharename, client, operation string, pce *SMBProfileCallEntry) prometheus.Metric {
 	return prometheus.MustNewConstMetric(
 		col.dsc[1],
 		prometheus.GaugeValue,
 		float64(pce.Inbytes),
+		col.netbiosName,
+		sharename,
+		client,
 		operation)
 }
 
-func (col *smbProfileCollector) smb2RequestOutbytesMetric(operation string,
-	pce *SMBProfileCallEntry) prometheus.Metric {
+func (col *smbProfileCollector) smb2RequestOutbytesMetric(
+	sharename, client, operation string, pce *SMBProfileCallEntry) prometheus.Metric {
 	return prometheus.MustNewConstMetric(
 		col.dsc[2],
 		prometheus.GaugeValue,
 		float64(pce.Outbytes),
+		col.netbiosName,
+		sharename,
+		client,
 		operation)
 }
 
-func (col *smbProfileCollector) smb2RequestDurationMetric(operation string,
-	pce *SMBProfileCallEntry) prometheus.Metric {
+func (col *smbProfileCollector) smb2RequestDurationMetric(
+	sharename, client, operation string, pce *SMBProfileCallEntry) prometheus.Metric {
 	return prometheus.MustNewConstMetric(
 		col.dsc[3],
 		prometheus.GaugeValue,
 		float64(pce.Time),
+		col.netbiosName,
+		sharename,
+		client,
 		operation)
 }
 
-func (col *smbProfileCollector) vfsIOTotalMetric(operation string,
-	pioe *SMBProfileIOEntry) prometheus.Metric {
+func (col *smbProfileCollector) vfsIOTotalMetric(
+	sharename, client, operation string, pioe *SMBProfileIOEntry) prometheus.Metric {
 	return prometheus.MustNewConstMetric(
 		col.dsc[4],
 		prometheus.GaugeValue,
 		float64(pioe.Count),
+		col.netbiosName,
+		sharename,
+		client,
 		operation)
 }
 
-func (col *smbProfileCollector) vfsIOBytesMetric(operation string,
-	pioe *SMBProfileIOEntry) prometheus.Metric {
+func (col *smbProfileCollector) vfsIOBytesMetric(
+	sharename, client, operation string, pioe *SMBProfileIOEntry) prometheus.Metric {
 	return prometheus.MustNewConstMetric(
 		col.dsc[5],
 		prometheus.GaugeValue,
 		float64(pioe.Bytes),
+		col.netbiosName,
+		sharename,
+		client,
 		operation)
 }
 
-func (col *smbProfileCollector) vfsIODurationMetric(operation string,
-	pioe *SMBProfileIOEntry) prometheus.Metric {
+func (col *smbProfileCollector) vfsIODurationMetric(
+	sharename, client, operation string, pioe *SMBProfileIOEntry) prometheus.Metric {
 	return prometheus.MustNewConstMetric(
 		col.dsc[6],
 		prometheus.GaugeValue,
 		float64(pioe.Time),
+		col.netbiosName,
+		sharename,
+		client,
 		operation)
 }
 
-func (col *smbProfileCollector) vfsTotalMetric(operation string,
-	pe *SMBProfileEntry) prometheus.Metric {
+func (col *smbProfileCollector) vfsTotalMetric(
+	sharename, client, operation string, pe *SMBProfileEntry) prometheus.Metric {
 	return prometheus.MustNewConstMetric(
 		col.dsc[7],
 		prometheus.GaugeValue,
 		float64(pe.Count),
+		col.netbiosName,
+		sharename,
+		client,
 		operation)
 }
 
-func (col *smbProfileCollector) vfsDurationMetric(operation string,
-	pe *SMBProfileEntry) prometheus.Metric {
+func (col *smbProfileCollector) vfsDurationMetric(
+	sharename, client, operation string, pe *SMBProfileEntry) prometheus.Metric {
 	return prometheus.MustNewConstMetric(
 		col.dsc[8],
 		prometheus.GaugeValue,
 		float64(pe.Time),
+		col.netbiosName,
+		sharename,
+		client,
 		operation)
 }
 
 func (sme *smbMetricsExporter) newSMBProfileCollector() prometheus.Collector {
+	variableLabels := []string{"netbiosname", "share", "client", "operation"}
 	col := &smbProfileCollector{}
 	col.sme = sme
 	col.dsc = []*prometheus.Desc{
 		prometheus.NewDesc(
 			collectorName("smb2", "request_total"),
 			"Total number of SMB2 requests",
-			[]string{"operation"}, nil),
+			variableLabels, nil),
 		prometheus.NewDesc(
 			collectorName("smb2", "request_inbytes"),
 			"Bytes received for SMB2 requests",
-			[]string{"operation"}, nil),
+			variableLabels, nil),
 		prometheus.NewDesc(
 			collectorName("smb2", "request_outbytes"),
 			"Bytes replied for SMB2 requests",
-			[]string{"operation"}, nil),
+			variableLabels, nil),
 		prometheus.NewDesc(
 			collectorName("smb2", "request_duration_microseconds_sum"),
 			"Execution time in microseconds of SMB2 requests",
-			[]string{"operation"}, nil),
+			variableLabels, nil),
 		prometheus.NewDesc(
 			collectorName("vfs_io", "total"),
 			"Total number of I/O calls to underlying VFS layer",
-			[]string{"operation"}, nil),
+			variableLabels, nil),
 		prometheus.NewDesc(
 			collectorName("vfs_io", "bytes"),
 			"Number of bytes transferred via underlying VFS I/O layer",
-			[]string{"operation"}, nil),
+			variableLabels, nil),
 		prometheus.NewDesc(
 			collectorName("vfs_io", "duration_microseconds_sum"),
 			"Execution time in microseconds of VFS I/O requests",
-			[]string{"operation"}, nil),
+			variableLabels, nil),
 		prometheus.NewDesc(
 			collectorName("vfs", "total"),
 			"Total number of calls to underlying VFS layer",
-			[]string{"operation"}, nil),
+			variableLabels, nil),
 		prometheus.NewDesc(
 			collectorName("vfs", "duration_microseconds_sum"),
 			"Execution time in microseconds of VFS requests",
-			[]string{"operation"}, nil),
+			variableLabels, nil),
 	}
 
 	return col

--- a/internal/metrics/smbstatus.go
+++ b/internal/metrics/smbstatus.go
@@ -456,14 +456,16 @@ func (smbstat *SMBStatus) ListTreeCons() []SMBStatusTreeCon {
 // share-name and client-ip as string. Returns a pair of empty strings in case
 // of parse failure.
 func ParseExtendedProfileKey(key string) (shareName, clientIP string) {
+	shareName = ""
+	clientIP = ""
 	sp := strings.Split(key, ":")
 	if len(sp) != 2 {
-		return "", ""
+		return
 	}
 	shareName = sp[0]
 	sp = strings.Split(sp[1], "[")
 	if len(sp) != 2 {
-		return "", ""
+		return
 	}
 	clientIP = strings.Trim(sp[1], "[]")
 	return

--- a/internal/metrics/smbstatus.go
+++ b/internal/metrics/smbstatus.go
@@ -451,3 +451,20 @@ func (smbstat *SMBStatus) ListTreeCons() []SMBStatusTreeCon {
 	}
 	return tcons
 }
+
+// ParseExtendedProfileKey parse the extended profile key into a pair of
+// share-name and client-ip as string. Returns a pair of empty strings in case
+// of parse failure.
+func ParseExtendedProfileKey(key string) (shareName, clientIP string) {
+	sp := strings.Split(key, ":")
+	if len(sp) != 2 {
+		return "", ""
+	}
+	shareName = sp[0]
+	sp = strings.Split(sp[1], "[")
+	if len(sp) != 2 {
+		return "", ""
+	}
+	clientIP = strings.Trim(sp[1], "[]")
+	return
+}

--- a/internal/metrics/smbstatus.go
+++ b/internal/metrics/smbstatus.go
@@ -257,14 +257,21 @@ type SMBProfileSMB2Calls struct {
 	Break     SMBProfileCallEntry `json:"smb2_break"`
 }
 
-// SMBProfile represents (a subset of the) output of 'smbstatus --profile'
-type SMBProfile struct {
-	Timestamp   string               `json:"timestamp"`
-	Version     string               `json:"version"`
-	SmbConf     string               `json:"smb_conf"`
-	SmbdLoop    *SMBProfileLoop      `json:"SMBD loop"`
+// SMBProfileShare represents per-share profile information
+type SMBProfileShare struct {
 	SystemCalls *SMBProfileSyscalls  `json:"System Calls"`
 	SMB2Calls   *SMBProfileSMB2Calls `json:"SMB2 Calls"`
+}
+
+// SMBProfile represents (a subset of the) output of 'smbstatus --profile'
+type SMBProfile struct {
+	Timestamp   string                      `json:"timestamp"`
+	Version     string                      `json:"version"`
+	SmbConf     string                      `json:"smb_conf"`
+	SmbdLoop    *SMBProfileLoop             `json:"SMBD loop"`
+	SystemCalls *SMBProfileSyscalls         `json:"System Calls"`
+	SMB2Calls   *SMBProfileSMB2Calls        `json:"SMB2 Calls"`
+	Extended    map[string]*SMBProfileShare `json:"Extended Profile"`
 }
 
 // LocateSMBStatus finds the local executable of 'smbstatus' on host.

--- a/internal/metrics/smbstatus_test.go
+++ b/internal/metrics/smbstatus_test.go
@@ -5,6 +5,7 @@ package metrics
 import (
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -155,6 +156,11 @@ func TestParseSMBStatusProfilePerShare(t *testing.T) {
 		assert.Greater(t, pershare.SystemCalls.Readdir.Time, 1)
 		assert.Greater(t, pershare.SMB2Calls.Find.Inbytes, 1)
 		assert.Greater(t, pershare.SMB2Calls.Find.Outbytes, 1)
+
+		shareName, clientIP := ParseExtendedProfileKey(key)
+		assert.NotEmpty(t, shareName)
+		assert.NotEmpty(t, clientIP)
+		assert.True(t, strings.HasPrefix(shareName, "smbshare"))
 	}
 }
 

--- a/internal/metrics/testdata/smbstatus-profile-per-share.json
+++ b/internal/metrics/testdata/smbstatus-profile-per-share.json
@@ -1,0 +1,1628 @@
+{
+  "timestamp": "2025-05-21T13:37:43.334965+0300",
+  "version": "4.23.0pre1-GIT-7dc009e9727",
+  "smb_conf": "//etc/samba/smb.conf",
+  "SMBD loop": {
+    "connect": {
+      "count": 1
+    },
+    "disconnect": {
+      "count": 0
+    },
+    "idle": {
+      "count": 164,
+      "time": 365400653
+    },
+    "cpu_user": {
+      "time": 42116
+    },
+    "cpu_system": {
+      "time": 37867
+    },
+    "request": {
+      "count": 152
+    },
+    "push_sec_ctx": {
+      "count": 163,
+      "time": 1629
+    },
+    "set_sec_ctx": {
+      "count": 33,
+      "time": 2429
+    },
+    "set_root_sec_ctx": {
+      "count": 180,
+      "time": 3009
+    },
+    "pop_sec_ctx": {
+      "count": 163,
+      "time": 1718
+    },
+    "num_sessions": {
+      "count": 1
+    },
+    "num_tcons": {
+      "count": 3
+    },
+    "num_files": {
+      "count": 0
+    }
+  },
+  "Authentication": {
+    "authentication": {
+      "count": 1
+    },
+    "authentication_failed": {
+      "count": 0
+    }
+  },
+  "System Calls": {
+    "syscall_opendir": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_fdopendir": {
+      "count": 16,
+      "time": 150
+    },
+    "syscall_readdir": {
+      "count": 83,
+      "time": 282
+    },
+    "syscall_rewinddir": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_mkdirat": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_closedir": {
+      "count": 16,
+      "time": 106
+    },
+    "syscall_open": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_openat": {
+      "count": 154,
+      "time": 1577
+    },
+    "syscall_createfile": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_close": {
+      "count": 134,
+      "time": 652
+    },
+    "syscall_pread": {
+      "count": 0,
+      "time": 0,
+      "idle": 0,
+      "bytes": 0
+    },
+    "syscall_asys_pread": {
+      "count": 3,
+      "time": 586,
+      "idle": 553,
+      "bytes": 339
+    },
+    "syscall_pwrite": {
+      "count": 0,
+      "time": 0,
+      "idle": 0,
+      "bytes": 0
+    },
+    "syscall_asys_pwrite": {
+      "count": 2,
+      "time": 883,
+      "idle": 311,
+      "bytes": 226
+    },
+    "syscall_lseek": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_sendfile": {
+      "count": 0,
+      "time": 0,
+      "idle": 0,
+      "bytes": 0
+    },
+    "syscall_recvfile": {
+      "count": 0,
+      "time": 0,
+      "idle": 0,
+      "bytes": 0
+    },
+    "syscall_renameat": {
+      "count": 1,
+      "time": 16
+    },
+    "syscall_asys_fsync": {
+      "count": 1,
+      "time": 3644,
+      "idle": 165,
+      "bytes": 0
+    },
+    "syscall_stat": {
+      "count": 139,
+      "time": 789
+    },
+    "syscall_fstat": {
+      "count": 207,
+      "time": 728
+    },
+    "syscall_lstat": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_fstatat": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_get_alloc_size": {
+      "count": 97,
+      "time": 58
+    },
+    "syscall_unlinkat": {
+      "count": 1,
+      "time": 57
+    },
+    "syscall_chmod": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_fchmod": {
+      "count": 1,
+      "time": 13
+    },
+    "syscall_fchown": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_lchown": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_chdir": {
+      "count": 57,
+      "time": 546
+    },
+    "syscall_getwd": {
+      "count": 3,
+      "time": 18
+    },
+    "syscall_fntimes": {
+      "count": 2,
+      "time": 17
+    },
+    "syscall_ftruncate": {
+      "count": 1,
+      "time": 90
+    },
+    "syscall_fallocate": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_fcntl_lock": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_fcntl": {
+      "count": 14,
+      "time": 37
+    },
+    "syscall_linux_setlease": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_fcntl_getlock": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_readlinkat": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_symlinkat": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_linkat": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_mknodat": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_realpath": {
+      "count": 6,
+      "time": 53
+    },
+    "syscall_get_quota": {
+      "count": 12,
+      "time": 1885
+    },
+    "syscall_set_quota": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_get_sd": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_set_sd": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_brl_lock": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_brl_unlock": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_brl_cancel": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_asys_getxattrat": {
+      "count": 0,
+      "time": 0,
+      "idle": 0,
+      "bytes": 0
+    }
+  },
+  "ACL Calls": {
+    "get_nt_acl": {
+      "count": 0,
+      "time": 0
+    },
+    "get_nt_acl_at": {
+      "count": 0,
+      "time": 0
+    },
+    "fget_nt_acl": {
+      "count": 32,
+      "time": 10596
+    },
+    "fset_nt_acl": {
+      "count": 0,
+      "time": 0
+    }
+  },
+  "Stat Cache": {
+    "statcache_lookups": {
+      "count": 4
+    },
+    "statcache_misses": {
+      "count": 4
+    },
+    "statcache_hits": {
+      "count": 0
+    }
+  },
+  "SMB Calls": {
+    "SMBmkdir": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBrmdir": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBopen": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBcreate": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBclose": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBflush": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBunlink": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBmv": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBgetatr": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsetatr": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBread": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBwrite": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBlock": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBunlock": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBctemp": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBmknew": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBcheckpath": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBexit": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBlseek": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBlockread": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBwriteunlock": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBreadbraw": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBreadBmpx": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBreadBs": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBwritebraw": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBwriteBmpx": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBwriteBs": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBwritec": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsetattrE": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBgetattrE": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBlockingX": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBtrans": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBtranss": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBioctl": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBioctls": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBcopy": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBmove": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBecho": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBwriteclose": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBopenX": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBreadX": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBwriteX": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBtrans2": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBtranss2": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBfindclose": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBfindnclose": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBtcon": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBtdis": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBnegprot": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsesssetupX": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBulogoffX": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBtconX": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBdskattr": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsearch": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBffirst": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBfunique": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBfclose": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBnttrans": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBnttranss": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBntcreateX": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBntcancel": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBntrename": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsplopen": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsplwr": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsplclose": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsplretq": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsends": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsendb": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBfwdname": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBcancelf": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBgetmac": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsendstrt": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsendend": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsendtxt": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBinvalid": {
+      "count": 0,
+      "time": 0
+    }
+  },
+  "Trans2 Calls": {
+    "Trans2_open": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_findfirst": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_findnext": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_qfsinfo": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_setfsinfo": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_qpathinfo": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_setpathinfo": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_qfileinfo": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_setfileinfo": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_fsctl": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_ioctl": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_findnotifyfirst": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_findnotifynext": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_mkdir": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_session_setup": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_get_dfs_referral": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_report_dfs_inconsistancy": {
+      "count": 0,
+      "time": 0
+    }
+  },
+  "NT Transact Calls": {
+    "NT_transact_create": {
+      "count": 0,
+      "time": 0
+    },
+    "NT_transact_ioctl": {
+      "count": 0,
+      "time": 0
+    },
+    "NT_transact_set_security_desc": {
+      "count": 0,
+      "time": 0
+    },
+    "NT_transact_notify_change": {
+      "count": 0,
+      "time": 0
+    },
+    "NT_transact_rename": {
+      "count": 0,
+      "time": 0
+    },
+    "NT_transact_query_security_desc": {
+      "count": 0,
+      "time": 0
+    },
+    "NT_transact_get_user_quota": {
+      "count": 0,
+      "time": 0
+    },
+    "NT_transact_set_user_quota": {
+      "count": 0,
+      "time": 0
+    }
+  },
+  "SMB2 Calls": {
+    "smb2_negprot": {
+      "count": 1,
+      "failed_count": 0,
+      "time": 3795849,
+      "idle": 0,
+      "inbytes": 240,
+      "outbytes": 296
+    },
+    "smb2_sesssetup": {
+      "count": 2,
+      "failed_count": 0,
+      "time": 3749,
+      "idle": 0,
+      "inbytes": 430,
+      "outbytes": 264
+    },
+    "smb2_logoff": {
+      "count": 0,
+      "failed_count": 0,
+      "time": 0,
+      "idle": 0,
+      "inbytes": 0,
+      "outbytes": 0
+    },
+    "smb2_tcon": {
+      "count": 3,
+      "failed_count": 0,
+      "time": 3601,
+      "idle": 0,
+      "inbytes": 368,
+      "outbytes": 240
+    },
+    "smb2_tdis": {
+      "count": 0,
+      "failed_count": 0,
+      "time": 0,
+      "idle": 0,
+      "inbytes": 0,
+      "outbytes": 0
+    },
+    "smb2_create": {
+      "count": 39,
+      "failed_count": 1,
+      "time": 28911,
+      "idle": 0,
+      "inbytes": 7512,
+      "outbytes": 9380
+    },
+    "smb2_close": {
+      "count": 38,
+      "failed_count": 0,
+      "time": 5474,
+      "idle": 0,
+      "inbytes": 3344,
+      "outbytes": 4740
+    },
+    "smb2_flush": {
+      "count": 1,
+      "failed_count": 0,
+      "time": 3658,
+      "idle": 0,
+      "inbytes": 88,
+      "outbytes": 68
+    },
+    "smb2_read": {
+      "count": 3,
+      "failed_count": 0,
+      "time": 666,
+      "idle": 0,
+      "inbytes": 339,
+      "outbytes": 579
+    },
+    "smb2_write": {
+      "count": 2,
+      "failed_count": 0,
+      "time": 1069,
+      "idle": 0,
+      "inbytes": 450,
+      "outbytes": 160
+    },
+    "smb2_lock": {
+      "count": 0,
+      "failed_count": 0,
+      "time": 0,
+      "idle": 0,
+      "inbytes": 0,
+      "outbytes": 0
+    },
+    "smb2_ioctl": {
+      "count": 5,
+      "failed_count": 2,
+      "time": 954,
+      "idle": 0,
+      "inbytes": 770,
+      "outbytes": 678
+    },
+    "smb2_cancel": {
+      "count": 0,
+      "failed_count": 0,
+      "time": 0,
+      "idle": 0,
+      "inbytes": 0,
+      "outbytes": 0
+    },
+    "smb2_keepalive": {
+      "count": 4,
+      "failed_count": 0,
+      "time": 18,
+      "idle": 0,
+      "inbytes": 272,
+      "outbytes": 272
+    },
+    "smb2_find": {
+      "count": 24,
+      "failed_count": 0,
+      "time": 4918,
+      "idle": 0,
+      "inbytes": 2352,
+      "outbytes": 5260
+    },
+    "smb2_notify": {
+      "count": 0,
+      "failed_count": 0,
+      "time": 0,
+      "idle": 0,
+      "inbytes": 0,
+      "outbytes": 0
+    },
+    "smb2_getinfo": {
+      "count": 25,
+      "failed_count": 0,
+      "time": 3080,
+      "idle": 0,
+      "inbytes": 2608,
+      "outbytes": 3376
+    },
+    "smb2_setinfo": {
+      "count": 3,
+      "failed_count": 0,
+      "time": 591,
+      "idle": 0,
+      "inbytes": 368,
+      "outbytes": 204
+    },
+    "smb2_break": {
+      "count": 0,
+      "failed_count": 0,
+      "time": 0,
+      "idle": 0,
+      "inbytes": 0,
+      "outbytes": 0
+    }
+  },
+  "Extended Profile": {
+    "smbshare1:10949.0[192.168.122.108]": {
+      "System Calls": {
+        "syscall_opendir": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fdopendir": {
+          "count": 9,
+          "time": 82
+        },
+        "syscall_readdir": {
+          "count": 48,
+          "time": 120
+        },
+        "syscall_rewinddir": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_mkdirat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_closedir": {
+          "count": 9,
+          "time": 50
+        },
+        "syscall_open": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_openat": {
+          "count": 84,
+          "time": 778
+        },
+        "syscall_createfile": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_close": {
+          "count": 72,
+          "time": 345
+        },
+        "syscall_pread": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_asys_pread": {
+          "count": 3,
+          "time": 586,
+          "idle": 551,
+          "bytes": 339
+        },
+        "syscall_pwrite": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_asys_pwrite": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_lseek": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_sendfile": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_recvfile": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_renameat": {
+          "count": 1,
+          "time": 16
+        },
+        "syscall_asys_fsync": {
+          "count": 1,
+          "time": 3637,
+          "idle": 159,
+          "bytes": 0
+        },
+        "syscall_stat": {
+          "count": 73,
+          "time": 404
+        },
+        "syscall_fstat": {
+          "count": 111,
+          "time": 367
+        },
+        "syscall_lstat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fstatat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_get_alloc_size": {
+          "count": 52,
+          "time": 21
+        },
+        "syscall_unlinkat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_chmod": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fchmod": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fchown": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_lchown": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_chdir": {
+          "count": 30,
+          "time": 312
+        },
+        "syscall_getwd": {
+          "count": 1,
+          "time": 7
+        },
+        "syscall_fntimes": {
+          "count": 2,
+          "time": 17
+        },
+        "syscall_ftruncate": {
+          "count": 1,
+          "time": 91
+        },
+        "syscall_fallocate": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fcntl_lock": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fcntl": {
+          "count": 8,
+          "time": 18
+        },
+        "syscall_linux_setlease": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fcntl_getlock": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_readlinkat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_symlinkat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_linkat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_mknodat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_realpath": {
+          "count": 2,
+          "time": 9
+        },
+        "syscall_get_quota": {
+          "count": 6,
+          "time": 1142
+        },
+        "syscall_set_quota": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_get_sd": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_set_sd": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_brl_lock": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_brl_unlock": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_brl_cancel": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_asys_getxattrat": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        }
+      },
+      "SMB2 Calls": {
+        "smb2_negprot": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_sesssetup": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_logoff": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_tcon": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_tdis": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_create": {
+          "count": 21,
+          "failed_count": 1,
+          "time": 16860,
+          "idle": 0,
+          "inbytes": 4056,
+          "outbytes": 4992
+        },
+        "smb2_close": {
+          "count": 20,
+          "failed_count": 0,
+          "time": 2890,
+          "idle": 0,
+          "inbytes": 1760,
+          "outbytes": 2496
+        },
+        "smb2_flush": {
+          "count": 1,
+          "failed_count": 0,
+          "time": 3659,
+          "idle": 0,
+          "inbytes": 88,
+          "outbytes": 68
+        },
+        "smb2_read": {
+          "count": 3,
+          "failed_count": 0,
+          "time": 666,
+          "idle": 0,
+          "inbytes": 339,
+          "outbytes": 579
+        },
+        "smb2_write": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_lock": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_ioctl": {
+          "count": 1,
+          "failed_count": 0,
+          "time": 667,
+          "idle": 0,
+          "inbytes": 176,
+          "outbytes": 124
+        },
+        "smb2_cancel": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_keepalive": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_find": {
+          "count": 12,
+          "failed_count": 0,
+          "time": 2903,
+          "idle": 0,
+          "inbytes": 1176,
+          "outbytes": 2718
+        },
+        "smb2_notify": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_getinfo": {
+          "count": 13,
+          "failed_count": 0,
+          "time": 1807,
+          "idle": 0,
+          "inbytes": 1356,
+          "outbytes": 1780
+        },
+        "smb2_setinfo": {
+          "count": 3,
+          "failed_count": 0,
+          "time": 591,
+          "idle": 0,
+          "inbytes": 368,
+          "outbytes": 204
+        },
+        "smb2_break": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        }
+      }
+    },
+    "smbshare2:10949.1[192.168.122.108]": {
+      "System Calls": {
+        "syscall_opendir": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fdopendir": {
+          "count": 7,
+          "time": 67
+        },
+        "syscall_readdir": {
+          "count": 35,
+          "time": 157
+        },
+        "syscall_rewinddir": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_mkdirat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_closedir": {
+          "count": 7,
+          "time": 52
+        },
+        "syscall_open": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_openat": {
+          "count": 70,
+          "time": 759
+        },
+        "syscall_createfile": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_close": {
+          "count": 62,
+          "time": 285
+        },
+        "syscall_pread": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_asys_pread": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_pwrite": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_asys_pwrite": {
+          "count": 2,
+          "time": 884,
+          "idle": 312,
+          "bytes": 226
+        },
+        "syscall_lseek": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_sendfile": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_recvfile": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_renameat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_asys_fsync": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_stat": {
+          "count": 62,
+          "time": 350
+        },
+        "syscall_fstat": {
+          "count": 96,
+          "time": 342
+        },
+        "syscall_lstat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fstatat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_get_alloc_size": {
+          "count": 45,
+          "time": 12
+        },
+        "syscall_unlinkat": {
+          "count": 1,
+          "time": 57
+        },
+        "syscall_chmod": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fchmod": {
+          "count": 1,
+          "time": 12
+        },
+        "syscall_fchown": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_lchown": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_chdir": {
+          "count": 25,
+          "time": 191
+        },
+        "syscall_getwd": {
+          "count": 1,
+          "time": 4
+        },
+        "syscall_fntimes": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_ftruncate": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fallocate": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fcntl_lock": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fcntl": {
+          "count": 6,
+          "time": 16
+        },
+        "syscall_linux_setlease": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fcntl_getlock": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_readlinkat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_symlinkat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_linkat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_mknodat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_realpath": {
+          "count": 2,
+          "time": 36
+        },
+        "syscall_get_quota": {
+          "count": 6,
+          "time": 740
+        },
+        "syscall_set_quota": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_get_sd": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_set_sd": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_brl_lock": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_brl_unlock": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_brl_cancel": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_asys_getxattrat": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        }
+      },
+      "SMB2 Calls": {
+        "smb2_negprot": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_sesssetup": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_logoff": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_tcon": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_tdis": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_create": {
+          "count": 18,
+          "failed_count": 0,
+          "time": 12046,
+          "idle": 0,
+          "inbytes": 3456,
+          "outbytes": 4388
+        },
+        "smb2_close": {
+          "count": 18,
+          "failed_count": 0,
+          "time": 2568,
+          "idle": 0,
+          "inbytes": 1584,
+          "outbytes": 2244
+        },
+        "smb2_flush": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_read": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_write": {
+          "count": 2,
+          "failed_count": 0,
+          "time": 1071,
+          "idle": 0,
+          "inbytes": 450,
+          "outbytes": 160
+        },
+        "smb2_lock": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_ioctl": {
+          "count": 1,
+          "failed_count": 0,
+          "time": 35,
+          "idle": 0,
+          "inbytes": 121,
+          "outbytes": 144
+        },
+        "smb2_cancel": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_keepalive": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_find": {
+          "count": 12,
+          "failed_count": 0,
+          "time": 2015,
+          "idle": 0,
+          "inbytes": 1176,
+          "outbytes": 2542
+        },
+        "smb2_notify": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_getinfo": {
+          "count": 12,
+          "failed_count": 0,
+          "time": 1273,
+          "idle": 0,
+          "inbytes": 1252,
+          "outbytes": 1596
+        },
+        "smb2_setinfo": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_break": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        }
+      }
+    }
+  }
+}

--- a/internal/metrics/testdata/smbstatus-profile-per-share2.json
+++ b/internal/metrics/testdata/smbstatus-profile-per-share2.json
@@ -1,0 +1,1664 @@
+{
+  "timestamp": "2025-06-25T12:32:11.052374+0300",
+  "version": "4.23.0pre1-GIT-89196c9875c",
+  "smb_conf": "//etc/samba/smb.conf",
+  "SMBD loop": {
+    "connect": {
+      "count": 2
+    },
+    "disconnect": {
+      "count": 0
+    },
+    "idle": {
+      "count": 297,
+      "time": 3115420073
+    },
+    "cpu_user": {
+      "time": 1033388
+    },
+    "cpu_system": {
+      "time": 977313
+    },
+    "request": {
+      "count": 150
+    },
+    "push_sec_ctx": {
+      "count": 201,
+      "time": 1394
+    },
+    "set_sec_ctx": {
+      "count": 14,
+      "time": 630
+    },
+    "set_root_sec_ctx": {
+      "count": 269,
+      "time": 6625
+    },
+    "pop_sec_ctx": {
+      "count": 201,
+      "time": 2860
+    },
+    "num_sessions": {
+      "count": 2
+    },
+    "num_tcons": {
+      "count": 4
+    },
+    "num_files": {
+      "count": 0
+    }
+  },
+  "Authentication": {
+    "authentication": {
+      "count": 2
+    },
+    "authentication_failed": {
+      "count": 0
+    }
+  },
+  "System Calls": {
+    "syscall_opendir": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_fdopendir": {
+      "count": 2,
+      "time": 16
+    },
+    "syscall_readdir": {
+      "count": 12,
+      "time": 4338
+    },
+    "syscall_rewinddir": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_mkdirat": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_closedir": {
+      "count": 2,
+      "time": 47
+    },
+    "syscall_open": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_openat": {
+      "count": 74,
+      "time": 5731
+    },
+    "syscall_createfile": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_close": {
+      "count": 72,
+      "time": 891
+    },
+    "syscall_pread": {
+      "count": 0,
+      "time": 0,
+      "idle": 0,
+      "bytes": 0
+    },
+    "syscall_asys_pread": {
+      "count": 3,
+      "time": 35556,
+      "idle": 9,
+      "bytes": 595
+    },
+    "syscall_pwrite": {
+      "count": 0,
+      "time": 0,
+      "idle": 0,
+      "bytes": 0
+    },
+    "syscall_asys_pwrite": {
+      "count": 1,
+      "time": 320,
+      "idle": 1,
+      "bytes": 11
+    },
+    "syscall_lseek": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_sendfile": {
+      "count": 0,
+      "time": 0,
+      "idle": 0,
+      "bytes": 0
+    },
+    "syscall_recvfile": {
+      "count": 0,
+      "time": 0,
+      "idle": 0,
+      "bytes": 0
+    },
+    "syscall_renameat": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_asys_fsync": {
+      "count": 1,
+      "time": 3191,
+      "idle": 3,
+      "bytes": 0
+    },
+    "syscall_stat": {
+      "count": 54,
+      "time": 1252
+    },
+    "syscall_fstat": {
+      "count": 144,
+      "time": 26707
+    },
+    "syscall_lstat": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_fstatat": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_get_alloc_size": {
+      "count": 57,
+      "time": 50
+    },
+    "syscall_unlinkat": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_chmod": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_fchmod": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_fchown": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_lchown": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_chdir": {
+      "count": 20,
+      "time": 466
+    },
+    "syscall_getwd": {
+      "count": 4,
+      "time": 12
+    },
+    "syscall_fntimes": {
+      "count": 3,
+      "time": 1468
+    },
+    "syscall_ftruncate": {
+      "count": 1,
+      "time": 17053
+    },
+    "syscall_fallocate": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_fcntl_lock": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_fcntl": {
+      "count": 8,
+      "time": 5
+    },
+    "syscall_linux_setlease": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_fcntl_getlock": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_readlinkat": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_symlinkat": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_linkat": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_mknodat": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_realpath": {
+      "count": 8,
+      "time": 36
+    },
+    "syscall_get_quota": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_set_quota": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_get_sd": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_set_sd": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_brl_lock": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_brl_unlock": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_brl_cancel": {
+      "count": 0,
+      "time": 0
+    },
+    "syscall_asys_getxattrat": {
+      "count": 0,
+      "time": 0,
+      "idle": 0,
+      "bytes": 0
+    }
+  },
+  "ACL Calls": {
+    "get_nt_acl": {
+      "count": 0,
+      "time": 0
+    },
+    "get_nt_acl_at": {
+      "count": 0,
+      "time": 0
+    },
+    "fget_nt_acl": {
+      "count": 10,
+      "time": 3574
+    },
+    "fset_nt_acl": {
+      "count": 0,
+      "time": 0
+    }
+  },
+  "Stat Cache": {
+    "statcache_lookups": {
+      "count": 0
+    },
+    "statcache_misses": {
+      "count": 0
+    },
+    "statcache_hits": {
+      "count": 0
+    }
+  },
+  "SMB Calls": {
+    "SMBmkdir": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBrmdir": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBopen": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBcreate": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBclose": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBflush": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBunlink": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBmv": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBgetatr": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsetatr": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBread": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBwrite": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBlock": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBunlock": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBctemp": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBmknew": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBcheckpath": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBexit": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBlseek": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBlockread": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBwriteunlock": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBreadbraw": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBreadBmpx": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBreadBs": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBwritebraw": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBwriteBmpx": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBwriteBs": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBwritec": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsetattrE": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBgetattrE": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBlockingX": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBtrans": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBtranss": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBioctl": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBioctls": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBcopy": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBmove": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBecho": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBwriteclose": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBopenX": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBreadX": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBwriteX": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBtrans2": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBtranss2": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBfindclose": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBfindnclose": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBtcon": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBtdis": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBnegprot": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsesssetupX": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBulogoffX": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBtconX": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBdskattr": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsearch": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBffirst": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBfunique": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBfclose": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBnttrans": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBnttranss": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBntcreateX": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBntcancel": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBntrename": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsplopen": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsplwr": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsplclose": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsplretq": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsends": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsendb": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBfwdname": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBcancelf": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBgetmac": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsendstrt": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsendend": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBsendtxt": {
+      "count": 0,
+      "time": 0
+    },
+    "SMBinvalid": {
+      "count": 0,
+      "time": 0
+    }
+  },
+  "Trans2 Calls": {
+    "Trans2_open": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_findfirst": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_findnext": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_qfsinfo": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_setfsinfo": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_qpathinfo": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_setpathinfo": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_qfileinfo": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_setfileinfo": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_fsctl": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_ioctl": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_findnotifyfirst": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_findnotifynext": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_mkdir": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_session_setup": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_get_dfs_referral": {
+      "count": 0,
+      "time": 0
+    },
+    "Trans2_report_dfs_inconsistancy": {
+      "count": 0,
+      "time": 0
+    }
+  },
+  "NT Transact Calls": {
+    "NT_transact_create": {
+      "count": 0,
+      "time": 0
+    },
+    "NT_transact_ioctl": {
+      "count": 0,
+      "time": 0
+    },
+    "NT_transact_set_security_desc": {
+      "count": 0,
+      "time": 0
+    },
+    "NT_transact_notify_change": {
+      "count": 0,
+      "time": 0
+    },
+    "NT_transact_rename": {
+      "count": 0,
+      "time": 0
+    },
+    "NT_transact_query_security_desc": {
+      "count": 0,
+      "time": 0
+    },
+    "NT_transact_get_user_quota": {
+      "count": 0,
+      "time": 0
+    },
+    "NT_transact_set_user_quota": {
+      "count": 0,
+      "time": 0
+    }
+  },
+  "SMB2 Calls": {
+    "smb2_negprot": {
+      "count": 2,
+      "failed_count": 0,
+      "time": 7544495,
+      "idle": 0,
+      "inbytes": 480,
+      "outbytes": 592
+    },
+    "smb2_sesssetup": {
+      "count": 4,
+      "failed_count": 0,
+      "time": 25393,
+      "idle": 0,
+      "inbytes": 860,
+      "outbytes": 528
+    },
+    "smb2_logoff": {
+      "count": 0,
+      "failed_count": 0,
+      "time": 0,
+      "idle": 0,
+      "inbytes": 0,
+      "outbytes": 0
+    },
+    "smb2_tcon": {
+      "count": 4,
+      "failed_count": 0,
+      "time": 205835,
+      "idle": 0,
+      "inbytes": 480,
+      "outbytes": 320
+    },
+    "smb2_tdis": {
+      "count": 0,
+      "failed_count": 0,
+      "time": 0,
+      "idle": 0,
+      "inbytes": 0,
+      "outbytes": 0
+    },
+    "smb2_create": {
+      "count": 28,
+      "failed_count": 0,
+      "time": 67360,
+      "idle": 0,
+      "inbytes": 5056,
+      "outbytes": 6576
+    },
+    "smb2_close": {
+      "count": 28,
+      "failed_count": 0,
+      "time": 5048,
+      "idle": 0,
+      "inbytes": 2464,
+      "outbytes": 3520
+    },
+    "smb2_flush": {
+      "count": 1,
+      "failed_count": 0,
+      "time": 3225,
+      "idle": 0,
+      "inbytes": 88,
+      "outbytes": 68
+    },
+    "smb2_read": {
+      "count": 3,
+      "failed_count": 0,
+      "time": 35664,
+      "idle": 0,
+      "inbytes": 339,
+      "outbytes": 835
+    },
+    "smb2_write": {
+      "count": 1,
+      "failed_count": 0,
+      "time": 646,
+      "idle": 0,
+      "inbytes": 123,
+      "outbytes": 80
+    },
+    "smb2_lock": {
+      "count": 0,
+      "failed_count": 0,
+      "time": 0,
+      "idle": 0,
+      "inbytes": 0,
+      "outbytes": 0
+    },
+    "smb2_ioctl": {
+      "count": 4,
+      "failed_count": 2,
+      "time": 1033,
+      "idle": 0,
+      "inbytes": 590,
+      "outbytes": 674
+    },
+    "smb2_cancel": {
+      "count": 0,
+      "failed_count": 0,
+      "time": 0,
+      "idle": 0,
+      "inbytes": 0,
+      "outbytes": 0
+    },
+    "smb2_keepalive": {
+      "count": 44,
+      "failed_count": 0,
+      "time": 332,
+      "idle": 0,
+      "inbytes": 2992,
+      "outbytes": 2992
+    },
+    "smb2_find": {
+      "count": 4,
+      "failed_count": 0,
+      "time": 5971,
+      "idle": 0,
+      "inbytes": 392,
+      "outbytes": 1034
+    },
+    "smb2_notify": {
+      "count": 0,
+      "failed_count": 0,
+      "time": 0,
+      "idle": 0,
+      "inbytes": 0,
+      "outbytes": 0
+    },
+    "smb2_getinfo": {
+      "count": 25,
+      "failed_count": 0,
+      "time": 12295,
+      "idle": 0,
+      "inbytes": 2608,
+      "outbytes": 3716
+    },
+    "smb2_setinfo": {
+      "count": 2,
+      "failed_count": 0,
+      "time": 1956,
+      "idle": 0,
+      "inbytes": 240,
+      "outbytes": 132
+    },
+    "smb2_break": {
+      "count": 0,
+      "failed_count": 0,
+      "time": 0,
+      "idle": 0,
+      "inbytes": 0,
+      "outbytes": 0
+    }
+  },
+  "Extended Profile": {
+    "smbshare:2308.0[192.168.122.25]": {
+      "System Calls": {
+        "syscall_opendir": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fdopendir": {
+          "count": 2,
+          "time": 16
+        },
+        "syscall_readdir": {
+          "count": 12,
+          "time": 4317
+        },
+        "syscall_rewinddir": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_mkdirat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_closedir": {
+          "count": 2,
+          "time": 46
+        },
+        "syscall_open": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_openat": {
+          "count": 45,
+          "time": 1387
+        },
+        "syscall_createfile": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_close": {
+          "count": 43,
+          "time": 459
+        },
+        "syscall_pread": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_asys_pread": {
+          "count": 2,
+          "time": 14908,
+          "idle": 6,
+          "bytes": 303
+        },
+        "syscall_pwrite": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_asys_pwrite": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_lseek": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_sendfile": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_recvfile": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_renameat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_asys_fsync": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_stat": {
+          "count": 28,
+          "time": 370
+        },
+        "syscall_fstat": {
+          "count": 85,
+          "time": 25654
+        },
+        "syscall_lstat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fstatat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_get_alloc_size": {
+          "count": 33,
+          "time": 15
+        },
+        "syscall_unlinkat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_chmod": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fchmod": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fchown": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_lchown": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_chdir": {
+          "count": 11,
+          "time": 211
+        },
+        "syscall_getwd": {
+          "count": 1,
+          "time": 1
+        },
+        "syscall_fntimes": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_ftruncate": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fallocate": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fcntl_lock": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fcntl": {
+          "count": 4,
+          "time": 1
+        },
+        "syscall_linux_setlease": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fcntl_getlock": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_readlinkat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_symlinkat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_linkat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_mknodat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_realpath": {
+          "count": 2,
+          "time": 4
+        },
+        "syscall_get_quota": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_set_quota": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_get_sd": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_set_sd": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_brl_lock": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_brl_unlock": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_brl_cancel": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_asys_getxattrat": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        }
+      },
+      "ACL Calls": {
+        "get_nt_acl": {
+          "count": 0,
+          "time": 0
+        },
+        "get_nt_acl_at": {
+          "count": 0,
+          "time": 0
+        },
+        "fget_nt_acl": {
+          "count": 7,
+          "time": 2484
+        },
+        "fset_nt_acl": {
+          "count": 0,
+          "time": 0
+        }
+      },
+      "SMB2 Calls": {
+        "smb2_negprot": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_sesssetup": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_logoff": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_tcon": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_tdis": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_create": {
+          "count": 15,
+          "failed_count": 0,
+          "time": 34037,
+          "idle": 0,
+          "inbytes": 2760,
+          "outbytes": 3576
+        },
+        "smb2_close": {
+          "count": 15,
+          "failed_count": 0,
+          "time": 2726,
+          "idle": 0,
+          "inbytes": 1320,
+          "outbytes": 1880
+        },
+        "smb2_flush": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_read": {
+          "count": 2,
+          "failed_count": 0,
+          "time": 14975,
+          "idle": 0,
+          "inbytes": 226,
+          "outbytes": 463
+        },
+        "smb2_write": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_lock": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_ioctl": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_cancel": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_keepalive": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_find": {
+          "count": 4,
+          "failed_count": 0,
+          "time": 5972,
+          "idle": 0,
+          "inbytes": 392,
+          "outbytes": 1034
+        },
+        "smb2_notify": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_getinfo": {
+          "count": 13,
+          "failed_count": 0,
+          "time": 11233,
+          "idle": 0,
+          "inbytes": 1356,
+          "outbytes": 1906
+        },
+        "smb2_setinfo": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_break": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        }
+      }
+    },
+    "smbshare:2329.0[192.168.122.108]": {
+      "System Calls": {
+        "syscall_opendir": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fdopendir": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_readdir": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_rewinddir": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_mkdirat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_closedir": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_open": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_openat": {
+          "count": 29,
+          "time": 4337
+        },
+        "syscall_createfile": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_close": {
+          "count": 29,
+          "time": 459
+        },
+        "syscall_pread": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_asys_pread": {
+          "count": 1,
+          "time": 20650,
+          "idle": 4,
+          "bytes": 292
+        },
+        "syscall_pwrite": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_asys_pwrite": {
+          "count": 1,
+          "time": 320,
+          "idle": 1,
+          "bytes": 11
+        },
+        "syscall_lseek": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_sendfile": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_recvfile": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        },
+        "syscall_renameat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_asys_fsync": {
+          "count": 1,
+          "time": 3192,
+          "idle": 3,
+          "bytes": 0
+        },
+        "syscall_stat": {
+          "count": 22,
+          "time": 841
+        },
+        "syscall_fstat": {
+          "count": 59,
+          "time": 1024
+        },
+        "syscall_lstat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fstatat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_get_alloc_size": {
+          "count": 24,
+          "time": 15
+        },
+        "syscall_unlinkat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_chmod": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fchmod": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fchown": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_lchown": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_chdir": {
+          "count": 7,
+          "time": 233
+        },
+        "syscall_getwd": {
+          "count": 1,
+          "time": 0
+        },
+        "syscall_fntimes": {
+          "count": 3,
+          "time": 1467
+        },
+        "syscall_ftruncate": {
+          "count": 1,
+          "time": 17052
+        },
+        "syscall_fallocate": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fcntl_lock": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fcntl": {
+          "count": 4,
+          "time": 1
+        },
+        "syscall_linux_setlease": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_fcntl_getlock": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_readlinkat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_symlinkat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_linkat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_mknodat": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_realpath": {
+          "count": 2,
+          "time": 3
+        },
+        "syscall_get_quota": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_set_quota": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_get_sd": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_set_sd": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_brl_lock": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_brl_unlock": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_brl_cancel": {
+          "count": 0,
+          "time": 0
+        },
+        "syscall_asys_getxattrat": {
+          "count": 0,
+          "time": 0,
+          "idle": 0,
+          "bytes": 0
+        }
+      },
+      "ACL Calls": {
+        "get_nt_acl": {
+          "count": 0,
+          "time": 0
+        },
+        "get_nt_acl_at": {
+          "count": 0,
+          "time": 0
+        },
+        "fget_nt_acl": {
+          "count": 3,
+          "time": 1089
+        },
+        "fset_nt_acl": {
+          "count": 0,
+          "time": 0
+        }
+      },
+      "SMB2 Calls": {
+        "smb2_negprot": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_sesssetup": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_logoff": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_tcon": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_tdis": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_create": {
+          "count": 13,
+          "failed_count": 0,
+          "time": 33315,
+          "idle": 0,
+          "inbytes": 2296,
+          "outbytes": 3000
+        },
+        "smb2_close": {
+          "count": 13,
+          "failed_count": 0,
+          "time": 2312,
+          "idle": 0,
+          "inbytes": 1144,
+          "outbytes": 1640
+        },
+        "smb2_flush": {
+          "count": 1,
+          "failed_count": 0,
+          "time": 3225,
+          "idle": 0,
+          "inbytes": 88,
+          "outbytes": 68
+        },
+        "smb2_read": {
+          "count": 1,
+          "failed_count": 0,
+          "time": 20691,
+          "idle": 0,
+          "inbytes": 113,
+          "outbytes": 372
+        },
+        "smb2_write": {
+          "count": 1,
+          "failed_count": 0,
+          "time": 646,
+          "idle": 0,
+          "inbytes": 123,
+          "outbytes": 80
+        },
+        "smb2_lock": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_ioctl": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_cancel": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_keepalive": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_find": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_notify": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        },
+        "smb2_getinfo": {
+          "count": 12,
+          "failed_count": 0,
+          "time": 1047,
+          "idle": 0,
+          "inbytes": 1252,
+          "outbytes": 1810
+        },
+        "smb2_setinfo": {
+          "count": 2,
+          "failed_count": 0,
+          "time": 1954,
+          "idle": 0,
+          "inbytes": 240,
+          "outbytes": 132
+        },
+        "smb2_break": {
+          "count": 0,
+          "failed_count": 0,
+          "time": 0,
+          "idle": 0,
+          "inbytes": 0,
+          "outbytes": 0
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
With per-share profile metrics now on Samba's [vfs_ceph_new](https://gitlab.com/samba-team/samba/-/commit/9f8d272b0ec456ca713f8afda71ccfe2acbe5e39)  master, support this mode also in Prometheus metrics using additional label.