### PR TITLE
workflows: build and push ceph20 based images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,3 +116,9 @@ jobs:
       - name: push dev container image
         # note: forcing use of docker here, since we did docker login above
         run: make CONTAINER_CMD=docker BASE_IMG_TAG=devbuilds-centos-amd64 image-push
+      - name: build ceph20 container image
+        # note: forcing use of docker here, since we did docker login above
+        run: make CONTAINER_CMD=docker BASE_IMG_TAG=ceph20-centos-amd64 image-build
+      - name: push ceph20 container image
+        # note: forcing use of docker here, since we did docker login above
+        run: make CONTAINER_CMD=docker BASE_IMG_TAG=ceph20-centos-amd64 image-push


### PR DESCRIPTION
The samba-container project recently established a new package source, `ceph20` intended to provide images for Ceph 20.y.z (aka tentacle). Create a ceph20 patterned image for the samba-metrics image too.