### PR TITLE
dockerfile: fix wrong args order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-# Args
 ARG BASE_IMG="quay.io/samba.org/samba-server:latest"
-ARG GIT_VERSION="(unset)"
-ARG COMMIT_ID="(unset)"
-ARG ARCH=""
 
 # Build smbmetrics
 FROM docker.io/golang:1.24 AS builder
+ARG GIT_VERSION="(unset)"
+ARG COMMIT_ID="(unset)"
+ARG ARCH=""
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
Commit 47959b5249 (image: allow passing explicit samba base-image) introduced the ability to set explicit base image and tag via command line args. However, it also introduced a bug in the Dockerfile flow which causes version and commit-id not to propagate properly into smbmetrics binary.