### PR TITLE
show program and platform info

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,8 +44,20 @@ jobs:
         run: git fetch
       - name: Lint git commit messages
         run: make check-gitlint
-  test:
+  show-versions:
     needs: [build, check]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+        with:
+          go-version: "stable"
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - name: Build
+        run: make
+      - name: Show info
+        run: ./bin/smbmetrics --show-versions
+  test:
+    needs: [show-versions]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"net"
 	"os"
 	goruntime "runtime"
@@ -34,7 +35,14 @@ func main() {
 	var noProfile bool
 	pflag.BoolVar(&noProfile, "no-profile", false,
 		"Run without collecting profile information")
+	var showVersions bool
+	pflag.BoolVar(&showVersions, "show-versions", false,
+		"Show versions info and exit")
 	pflag.Parse()
+
+	if showVersions {
+		showVersionsAndExit()
+	}
 
 	log := zap.New(zap.UseDevMode(true))
 	log.Info("Initializing smbmetrics",
@@ -70,4 +78,15 @@ func main() {
 	if err != nil {
 		os.Exit(1)
 	}
+}
+
+func showVersionsAndExit() {
+	vers, _ := metrics.ResolveVersions(nil)
+	fmt.Println("Progname:", os.Args[0])
+	fmt.Println("Version:", vers.Version)
+	fmt.Println("CommitID:", vers.CommitID)
+	fmt.Println("GoVersion:", goruntime.Version())
+	fmt.Println("Arch:", goruntime.GOARCH)
+	fmt.Println("SambaVersion:", vers.SambaVersion)
+	os.Exit(0)
 }

--- a/internal/metrics/versions.go
+++ b/internal/metrics/versions.go
@@ -5,6 +5,7 @@ package metrics
 import (
 	"context"
 	"errors"
+	"strings"
 )
 
 var (
@@ -35,8 +36,10 @@ func ResolveVersions(clnt *kclient) (Versions, error) {
 	if clnt != nil {
 		vers.SambaImage, imgErr = resolveSambaImage(clnt)
 	}
-	vers.SambaVersion, smbVersErr = resolveSambaVersion()
-	vers.CtdbVersion, ctdbVersErr = resolveCtdbVersion()
+	sambaVersion, smbVersErr := resolveSambaVersion()
+	vers.SambaVersion = strings.TrimSpace(sambaVersion)
+	ctdbVersion, ctdbVersErr := resolveCtdbVersion()
+	vers.CtdbVersion = strings.TrimSpace(ctdbVersion)
 	return vers, errors.Join(imgErr, smbVersErr, ctdbVersErr)
 }
 


### PR DESCRIPTION
Show program, version OS, CPU-arch, Go-version and exit when running as `smbmetrics --show-info`. Mostly a developer helper info but also in preparation for build and run over ARM64 (following PRs).