### PR TITLE
metrics: pre-allocate slices and maps with known capacity

### DIFF
--- a/internal/metrics/smbinfo.go
+++ b/internal/metrics/smbinfo.go
@@ -62,7 +62,7 @@ func (smbinfo *SMBInfo) TotalTreeCons() int {
 }
 
 func (smbinfo *SMBInfo) TotalConnectedUsers() int {
-	users := map[string]bool{}
+	users := make(map[string]bool, len(smbinfo.sessionsStatus.Sessions))
 	for _, session := range smbinfo.sessionsStatus.Sessions {
 		username := session.Username
 		if len(username) > 0 {
@@ -73,7 +73,7 @@ func (smbinfo *SMBInfo) TotalConnectedUsers() int {
 }
 
 func (smbinfo *SMBInfo) MapMachineToSessions() map[string][]*SMBStatusSession {
-	ret := map[string][]*SMBStatusSession{}
+	ret := make(map[string][]*SMBStatusSession, len(smbinfo.sessionsStatus.Sessions))
 	for _, session := range smbinfo.sessionsStatus.Sessions {
 		machineID := session.RemoteMachine
 		sessionRef := &session
@@ -83,7 +83,7 @@ func (smbinfo *SMBInfo) MapMachineToSessions() map[string][]*SMBStatusSession {
 }
 
 func (smbinfo *SMBInfo) MapServiceToTreeCons() map[string][]*SMBStatusTreeCon {
-	ret := map[string][]*SMBStatusTreeCon{}
+	ret := make(map[string][]*SMBStatusTreeCon, len(smbinfo.tconsStatus.TCons))
 	for _, tcon := range smbinfo.tconsStatus.TCons {
 		serviceID := tcon.Service
 		if isInternalServiceID(serviceID) {
@@ -96,7 +96,7 @@ func (smbinfo *SMBInfo) MapServiceToTreeCons() map[string][]*SMBStatusTreeCon {
 }
 
 func (smbinfo *SMBInfo) MapMachineToTreeCons() map[string][]*SMBStatusTreeCon {
-	ret := map[string][]*SMBStatusTreeCon{}
+	ret := make(map[string][]*SMBStatusTreeCon, len(smbinfo.tconsStatus.TCons))
 	for _, tcon := range smbinfo.tconsStatus.TCons {
 		serviceID := tcon.Service
 		if isInternalServiceID(serviceID) {
@@ -110,7 +110,7 @@ func (smbinfo *SMBInfo) MapMachineToTreeCons() map[string][]*SMBStatusTreeCon {
 }
 
 func (smbinfo *SMBInfo) MapServiceToMachines() map[string]map[string]int {
-	ret := map[string]map[string]int{}
+	ret := make(map[string]map[string]int, len(smbinfo.tconsStatus.TCons))
 	for _, tcon := range smbinfo.tconsStatus.TCons {
 		serviceID := tcon.Service
 		if isInternalServiceID(serviceID) {
@@ -128,7 +128,7 @@ func (smbinfo *SMBInfo) MapServiceToMachines() map[string]map[string]int {
 }
 
 func (smbinfo *SMBInfo) MapMachineToServies() map[string]map[string]int {
-	ret := map[string]map[string]int{}
+	ret := make(map[string]map[string]int, len(smbinfo.tconsStatus.TCons))
 	for _, tcon := range smbinfo.tconsStatus.TCons {
 		serviceID := tcon.Service
 		if isInternalServiceID(serviceID) {

--- a/internal/metrics/smbstatus.go
+++ b/internal/metrics/smbstatus.go
@@ -334,11 +334,11 @@ func RunSMBStatusLocks() ([]SMBStatusOpenFile, error) {
 }
 
 func parseSMBStatusLockedFiles(dat string) ([]SMBStatusOpenFile, error) {
-	lockedFiles := []SMBStatusOpenFile{}
 	res, err := parseSMBStatusLocks(dat)
 	if err != nil {
-		return lockedFiles, err
+		return []SMBStatusOpenFile{}, err
 	}
+	lockedFiles := make([]SMBStatusOpenFile, 0, len(res.OpenFiles))
 	for _, lfile := range res.OpenFiles {
 		lockedFiles = append(lockedFiles, lfile)
 	}
@@ -438,7 +438,7 @@ func NewSMBProfile() *SMBProfile {
 
 // ListSessions returns a slice for mapped sessions
 func (smbstat *SMBStatus) ListSessions() []SMBStatusSession {
-	sessions := []SMBStatusSession{}
+	sessions := make([]SMBStatusSession, 0, len(smbstat.Sessions))
 	for _, session := range smbstat.Sessions {
 		sessions = append(sessions, session)
 	}
@@ -447,7 +447,7 @@ func (smbstat *SMBStatus) ListSessions() []SMBStatusSession {
 
 // ListTreeCons returns a slice for mapped tree-connection
 func (smbstat *SMBStatus) ListTreeCons() []SMBStatusTreeCon {
-	tcons := []SMBStatusTreeCon{}
+	tcons := make([]SMBStatusTreeCon, 0, len(smbstat.TCons))
 	for _, share := range smbstat.TCons {
 		tcons = append(tcons, share)
 	}


### PR DESCRIPTION
Use make() with explicit capacity hints in order to avoid unnecessary allocations and rehashing.